### PR TITLE
Used forward declarations to fix clang and gcc 4.7 stricter template function reference checking

### DIFF
--- a/Horde3D/Source/Shared/rapidxml_print.h
+++ b/Horde3D/Source/Shared/rapidxml_print.h
@@ -62,7 +62,34 @@ namespace rapidxml
         ///////////////////////////////////////////////////////////////////////////
         // Internal character operations
         template<class OutIt, class Ch>
+        inline OutIt print(OutIt out, const xml_node<Ch> &node, int flags = 0);
+
+        template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+        template<class OutIt, class Ch>
+        inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
         
         // Copy characters from given range to given output iterator
         template<class OutIt, class Ch>


### PR DESCRIPTION
clang and gcc 4.7+ _really_ care about function declarations and rather than decoupling and inserting declarations in between their implementations here I just declared all the rapidxml printing internals at once. Building then continues as desired.

Tested to work on linux with clang 3.4 and gcc 4.7, OSX with clang 3.2 (Makefiles and XCode) gcc 4.2.

PS. I noticed a fix like this was in the develop branch but it still failed to build, I'd suggest merging this pull with master as otherwise it all builds quite nicely and I wouldn't want people to get turned off Horde3D because they have a newer compiler.
