### PR TITLE
Adds STATIC_H3D flag to create static libs.

### DIFF
--- a/Extensions/Terrain/Source/terrain.cpp
+++ b/Extensions/Terrain/Source/terrain.cpp
@@ -201,8 +201,8 @@ void TerrainNode::drawTerrainBlock( TerrainNode *terrain, float minU, float minV
 			terrain->_vertexBuffer, terrain->getVertexCount() * sizeof( float ) * 3,
 			terrain->getVertexCount() * sizeof( float ), terrain->_heightArray );
 		gRDI->drawIndexed( PRIM_TRISTRIP, 0, terrain->getIndexCount(), 0, terrain->getVertexCount() );
-		Modules::stats().incStat( EngineStats::BatchCount, 1 );
-		Modules::stats().incStat( EngineStats::TriCount, (terrain->_blockSize + 1) * (terrain->_blockSize + 1) * 2.0f );
+		Modules::stats().incStat( H3DStats::BatchCount, 1 );
+		Modules::stats().incStat( H3DStats::TriCount, (terrain->_blockSize + 1) * (terrain->_blockSize + 1) * 2.0f );
 	}
 	else 
 	{

--- a/Horde3D/Bindings/C++/Horde3D.h
+++ b/Horde3D/Bindings/C++/Horde3D.h
@@ -14,18 +14,25 @@
 
 #pragma once
 
+#ifdef STATIC_H3D
+#	define DLL extern "C"
+#else
 #ifndef DLL
 #	if defined( WIN32 ) || defined( _WINDOWS )
-#		define DLL extern "C" __declspec( dllimport )
-#	else
-#  if defined( __GNUC__ ) && __GNUC__ >= 4
-#   define DLL extern "C" __attribute__ ((visibility("default")))
-#  else
+#		ifdef Horde3D_EXPORTS
+#			define DLL extern "C" __declspec( dllexport )
+#		else
+#			define DLL extern "C" __declspec( dllimport )
+#	    endif
+#   else
+#   if defined( __GNUC__ ) && __GNUC__ >= 4
+#       define DLL extern "C" __attribute__ ((visibility("default")))
+#   else
 #		define DLL extern "C"
-#  endif
-#	endif
+#   endif
+#   endif
 #endif
-
+#endif
 
 /*	Topic: Conventions
 		Some conventions for the API.
@@ -485,17 +492,17 @@ struct H3DModel
 	/*	Enum: H3DModel
 			The available Model node parameters
 
-    GeoResI     - Geometry resource used for the model
-    SWSkinningI - Enables or disables software skinning (default: 0)
-    LodDist1F   - Distance to camera from which on LOD1 is used (default: infinite)
-                  (must be a positive value larger than 0.0)
-    LodDist2F   - Distance to camera from which on LOD2 is used
-                  (may not be smaller than LodDist1) (default: infinite)
-    LodDist3F   - Distance to camera from which on LOD3 is used
-                  (may not be smaller than LodDist2) (default: infinite)
-    LodDist4F   - Distance to camera from which on LOD4 is used
-                  (may not be smaller than LodDist3) (default: infinite)
-    AnimCountI  - Number of active animation stages [read-only]
+		GeoResI      - Geometry resource used for the model
+		SWSkinningI  - Enables or disables software skinning (default: 0)
+		LodDist1F    - Distance to camera from which on LOD1 is used (default: infinite)
+		               (must be a positive value larger than 0.0)
+		LodDist2F    - Distance to camera from which on LOD2 is used
+		               (may not be smaller than LodDist1) (default: infinite)
+		LodDist3F    - Distance to camera from which on LOD3 is used
+		               (may not be smaller than LodDist2) (default: infinite)
+		LodDist4F    - Distance to camera from which on LOD4 is used
+		               (may not be smaller than LodDist3) (default: infinite)
+		AnimCountI   - Number of active animation stages [read-only]
 	*/
 	enum List
 	{
@@ -504,8 +511,8 @@ struct H3DModel
 		LodDist1F,
 		LodDist2F,
 		LodDist3F,
-    LodDist4F,
-    AnimCountI
+		LodDist4F,
+		AnimCountI
 	};
 };
 

--- a/Horde3D/Bindings/C++/Horde3DUtils.h
+++ b/Horde3D/Bindings/C++/Horde3DUtils.h
@@ -16,19 +16,6 @@
 
 #include "Horde3D.h"
 
-#ifndef DLL
-#	if defined( WIN32 ) || defined( _WINDOWS )
-#		define DLL extern "C" __declspec( dllimport )
-#	else
-#  if defined( __GNUC__ ) && __GNUC__ >= 4
-#   define DLL extern "C" __attribute__ ((visibility("default")))
-#  else
-#		define DLL extern "C"
-#  endif
-#	endif
-#endif
-
-
 /*	Topic: Introduction
 		Some words about the Utility Library.
 	

--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -383,7 +383,7 @@ bool AnimationController::animate()
 	Quaternion nodeRotQuat;
 	Vec3f nodeTransVec, nodeScaleVec;
 	
-	Timer *timer = Modules::stats().getTimer( EngineStats::AnimationTime );
+	Timer *timer = Modules::stats().getTimer( H3DStats::AnimationTime );
 	if( Modules::config().gatherTimeStats ) timer->setEnabled( true );
 	
 	// Animate

--- a/Horde3D/Source/Horde3DEngine/egCom.cpp
+++ b/Horde3D/Source/Horde3DEngine/egCom.cpp
@@ -44,37 +44,37 @@ EngineConfig::EngineConfig()
 }
 
 
-float EngineConfig::getOption( EngineOptions::List param )
+float EngineConfig::getOption( H3DOptions::List param )
 {
 	switch( param )
 	{
-	case EngineOptions::MaxLogLevel:
+	case H3DOptions::MaxLogLevel:
 		return (float)maxLogLevel;
-	case EngineOptions::MaxNumMessages:
+	case H3DOptions::MaxNumMessages:
 		return (float)Modules::log().getMaxNumMessages();
-	case EngineOptions::TrilinearFiltering:
+	case H3DOptions::TrilinearFiltering:
 		return trilinearFiltering ? 1.0f : 0.0f;
-	case EngineOptions::MaxAnisotropy:
+	case H3DOptions::MaxAnisotropy:
 		return (float)maxAnisotropy;
-	case EngineOptions::TexCompression:
+	case H3DOptions::TexCompression:
 		return texCompression ? 1.0f : 0.0f;
-	case EngineOptions::SRGBLinearization:
+	case H3DOptions::SRGBLinearization:
 		return sRGBLinearization ? 1.0f : 0.0f;
-	case EngineOptions::LoadTextures:
+	case H3DOptions::LoadTextures:
 		return loadTextures ? 1.0f : 0.0f;
-	case EngineOptions::FastAnimation:
+	case H3DOptions::FastAnimation:
 		return fastAnimation ? 1.0f : 0.0f;
-	case EngineOptions::ShadowMapSize:
+	case H3DOptions::ShadowMapSize:
 		return (float)shadowMapSize;
-	case EngineOptions::SampleCount:
+	case H3DOptions::SampleCount:
 		return (float)sampleCount;
-	case EngineOptions::WireframeMode:
+	case H3DOptions::WireframeMode:
 		return wireframeMode ? 1.0f : 0.0f;
-	case EngineOptions::DebugViewMode:
+	case H3DOptions::DebugViewMode:
 		return debugViewMode ? 1.0f : 0.0f;
-	case EngineOptions::DumpFailedShaders:
+	case H3DOptions::DumpFailedShaders:
 		return dumpFailedShaders ? 1.0f : 0.0f;
-	case EngineOptions::GatherTimeStats:
+	case H3DOptions::GatherTimeStats:
 		return gatherTimeStats ? 1.0f : 0.0f;
 	default:
 		Modules::setError( "Invalid param for h3dGetOption" );
@@ -83,37 +83,37 @@ float EngineConfig::getOption( EngineOptions::List param )
 }
 
 
-bool EngineConfig::setOption( EngineOptions::List param, float value )
+bool EngineConfig::setOption( H3DOptions::List param, float value )
 {
 	int size;
 	
 	switch( param )
 	{
-	case EngineOptions::MaxLogLevel:
+	case H3DOptions::MaxLogLevel:
 		maxLogLevel = ftoi_r( value );
 		return true;
-	case EngineOptions::MaxNumMessages:
+	case H3DOptions::MaxNumMessages:
 		Modules::log().setMaxNumMessages( (uint32)ftoi_r( value ) );
 		return true;
-	case EngineOptions::TrilinearFiltering:
+	case H3DOptions::TrilinearFiltering:
 		trilinearFiltering = (value != 0);
 		return true;
-	case EngineOptions::MaxAnisotropy:
+	case H3DOptions::MaxAnisotropy:
 		maxAnisotropy = ftoi_r( value );
 		return true;
-	case EngineOptions::TexCompression:
+	case H3DOptions::TexCompression:
 		texCompression = (value != 0);
 		return true;
-	case EngineOptions::SRGBLinearization:
+	case H3DOptions::SRGBLinearization:
 		sRGBLinearization = (value != 0);
 		return true;
-	case EngineOptions::LoadTextures:
+	case H3DOptions::LoadTextures:
 		loadTextures = (value != 0);
 		return true;
-	case EngineOptions::FastAnimation:
+	case H3DOptions::FastAnimation:
 		fastAnimation = (value != 0);
 		return true;
-	case EngineOptions::ShadowMapSize:
+	case H3DOptions::ShadowMapSize:
 		size = ftoi_r( value );
 
 		if( size == shadowMapSize ) return true;
@@ -134,19 +134,19 @@ bool EngineConfig::setOption( EngineOptions::List param, float value )
 			shadowMapSize = size;
 			return true;
 		}
-	case EngineOptions::SampleCount:
+	case H3DOptions::SampleCount:
 		sampleCount = ftoi_r( value );
 		return true;
-	case EngineOptions::WireframeMode:
+	case H3DOptions::WireframeMode:
 		wireframeMode = (value != 0);
 		return true;
-	case EngineOptions::DebugViewMode:
+	case H3DOptions::DebugViewMode:
 		debugViewMode = (value != 0);
 		return true;
-	case EngineOptions::DumpFailedShaders:
+	case H3DOptions::DumpFailedShaders:
 		dumpFailedShaders = (value != 0);
 		return true;
-	case EngineOptions::GatherTimeStats:
+	case H3DOptions::GatherTimeStats:
 		gatherTimeStats = (value != 0);
 		return true;
 	default:
@@ -290,53 +290,53 @@ float StatManager::getStat( int param, bool reset )
 	
 	switch( param )
 	{
-	case EngineStats::TriCount:
+	case H3DStats::TriCount:
 		value = (float)_statTriCount;
 		if( reset ) _statTriCount = 0;
 		return value;
-	case EngineStats::BatchCount:
+	case H3DStats::BatchCount:
 		value = (float)_statBatchCount;
 		if( reset ) _statBatchCount = 0;
 		return value;
-	case EngineStats::LightPassCount:
+	case H3DStats::LightPassCount:
 		value = (float)_statLightPassCount;
 		if( reset ) _statLightPassCount = 0;
 		return value;
-	case EngineStats::FrameTime:
+	case H3DStats::FrameTime:
 		value = _frameTime;
 		if( reset ) _frameTime = 0;
 		return value;
-	case EngineStats::AnimationTime:
+	case H3DStats::AnimationTime:
 		value = _animTimer.getElapsedTimeMS();
 		if( reset ) _animTimer.reset();
 		return value;
-	case EngineStats::GeoUpdateTime:
+	case H3DStats::GeoUpdateTime:
 		value = _geoUpdateTimer.getElapsedTimeMS();
 		if( reset ) _geoUpdateTimer.reset();
 		return value;
-	case EngineStats::ParticleSimTime:
+	case H3DStats::ParticleSimTime:
 		value = _particleSimTimer.getElapsedTimeMS();
 		if( reset ) _particleSimTimer.reset();
 		return value;
-	case EngineStats::FwdLightsGPUTime:
+	case H3DStats::FwdLightsGPUTime:
 		value = _fwdLightsGPUTimer->getTimeMS();
 		if( reset ) _fwdLightsGPUTimer->reset();
 		return value;
-	case EngineStats::DefLightsGPUTime:
+	case H3DStats::DefLightsGPUTime:
 		value = _defLightsGPUTimer->getTimeMS();
 		if( reset ) _defLightsGPUTimer->reset();
 		return value;
-	case EngineStats::ParticleGPUTime:
+	case H3DStats::ParticleGPUTime:
 		value = _particleGPUTimer->getTimeMS();
 		if( reset ) _particleGPUTimer->reset();
 		return value;
-	case EngineStats::ShadowsGPUTime:
+	case H3DStats::ShadowsGPUTime:
 		value = _shadowsGPUTimer->getTimeMS();
 		if( reset ) _shadowsGPUTimer->reset();
 		return value;
-	case EngineStats::TextureVMem:
+	case H3DStats::TextureVMem:
 		return (gRDI->getTextureMem() / 1024) / 1024.0f;
-	case EngineStats::GeometryVMem:
+	case H3DStats::GeometryVMem:
 		return (gRDI->getBufferMem() / 1024) / 1024.0f;
 	default:
 		Modules::setError( "Invalid param for h3dGetStat" );
@@ -349,16 +349,16 @@ void StatManager::incStat( int param, float value )
 {
 	switch( param )
 	{
-	case EngineStats::TriCount:
+	case H3DStats::TriCount:
 		_statTriCount += ftoi_r( value );
 		break;
-	case EngineStats::BatchCount:
+	case H3DStats::BatchCount:
 		_statBatchCount += ftoi_r( value );
 		break;
-	case EngineStats::LightPassCount:
+	case H3DStats::LightPassCount:
 		_statLightPassCount += ftoi_r( value );
 		break;
-	case EngineStats::FrameTime:
+	case H3DStats::FrameTime:
 		_frameTime += value;
 		break;
 	}
@@ -369,13 +369,13 @@ Timer *StatManager::getTimer( int param )
 {
 	switch( param )
 	{
-	case EngineStats::FrameTime:
+	case H3DStats::FrameTime:
 		return &_frameTimer;
-	case EngineStats::AnimationTime:
+	case H3DStats::AnimationTime:
 		return &_animTimer;
-	case EngineStats::GeoUpdateTime:
+	case H3DStats::GeoUpdateTime:
 		return &_geoUpdateTimer;
-	case EngineStats::ParticleSimTime:
+	case H3DStats::ParticleSimTime:
 		return &_particleSimTimer;
 	default:
 		return 0x0;
@@ -387,13 +387,13 @@ GPUTimer *StatManager::getGPUTimer( int param )
 {
 	switch( param )
 	{
-	case EngineStats::FwdLightsGPUTime:
+	case H3DStats::FwdLightsGPUTime:
 		return _fwdLightsGPUTimer;
-	case EngineStats::DefLightsGPUTime:
+	case H3DStats::DefLightsGPUTime:
 		return _defLightsGPUTimer;
-	case EngineStats::ShadowsGPUTime:
+	case H3DStats::ShadowsGPUTime:
 		return _shadowsGPUTimer;
-	case EngineStats::ParticleGPUTime:
+	case H3DStats::ParticleGPUTime:
 		return _particleGPUTimer;
 	default:
 		return 0x0;

--- a/Horde3D/Source/Horde3DEngine/egCom.h
+++ b/Horde3D/Source/Horde3DEngine/egCom.h
@@ -13,6 +13,7 @@
 #ifndef _egCom_H_
 #define _egCom_H_
 
+#include "../../Bindings/C++/Horde3D.h"
 #include "egPrerequisites.h"
 #include <string>
 #include <queue>
@@ -28,36 +29,13 @@ class GPUTimer;
 // Engine Config
 // =================================================================================================
 
-struct EngineOptions
-{
-	enum List
-	{
-		MaxLogLevel = 1,
-		MaxNumMessages,
-		TrilinearFiltering,
-		MaxAnisotropy,
-		TexCompression,
-		SRGBLinearization,
-		LoadTextures,
-		FastAnimation,
-		ShadowMapSize,
-		SampleCount,
-		WireframeMode,
-		DebugViewMode,
-		DumpFailedShaders,
-		GatherTimeStats
-	};
-};
-
-// =================================================================================================
-
 class EngineConfig
 {
 public:
 	EngineConfig();
 
-	float getOption( EngineOptions::List param );
-	bool setOption( EngineOptions::List param, float value );
+	float getOption( H3DOptions::List param );
+	bool setOption( H3DOptions::List param, float value );
 
 public:
 	int   maxLogLevel;
@@ -122,31 +100,6 @@ protected:
 	char                      _textBuf[2048];
 	uint32                    _maxNumMessages;
 	std::queue< LogMessage >  _messages;
-};
-
-
-// =================================================================================================
-// Engine Stats
-// =================================================================================================
-
-struct EngineStats
-{
-	enum List
-	{
-		TriCount = 100,
-		BatchCount,
-		LightPassCount,
-		FrameTime,
-		AnimationTime,
-		GeoUpdateTime,
-		ParticleSimTime,
-		FwdLightsGPUTime,
-		DefLightsGPUTime,
-		ShadowsGPUTime,
-		ParticleGPUTime,
-		TextureVMem,
-		GeometryVMem
-	};
 };
 
 // =================================================================================================

--- a/Horde3D/Source/Horde3DEngine/egMain.cpp
+++ b/Horde3D/Source/Horde3DEngine/egMain.cpp
@@ -10,6 +10,7 @@
 //
 // *************************************************************************************************
 
+#include "Horde3D.h"
 #include "egModules.h"
 #include "egCom.h"
 #include "egExtensions.h"
@@ -147,26 +148,26 @@ DLLEXP const char *h3dGetMessage( int *level, float *time )
 }
 
 
-DLLEXP float h3dGetOption( EngineOptions::List param )
+DLLEXP float h3dGetOption( H3DOptions::List param )
 {
 	return Modules::config().getOption( param );
 }
 
 
-DLLEXP bool h3dSetOption( EngineOptions::List param, float value )
+DLLEXP bool h3dSetOption( H3DOptions::List param, float value )
 {
 	return Modules::config().setOption( param, value );
 }
 
 
-DLLEXP float h3dGetStat( EngineStats::List param, bool reset )
+DLLEXP float h3dGetStat( H3DStats::List param, bool reset )
 {
 	return Modules::stats().getStat( param, reset );
 }
 
 
 DLLEXP void h3dShowOverlays( const float *verts, int vertCount, float colR, float colG,
-                             float colB, float colA, uint32 materialRes, int flags )
+                             float colB, float colA, H3DRes materialRes, int flags )
 {
 	Resource *resObj = Modules::resMan().resolveResHandle( materialRes ); 
 	APIFUNC_VALIDATE_RES_TYPE( resObj, ResourceTypes::Material, "h3dShowOverlays", APIFUNC_RET_VOID );
@@ -925,7 +926,7 @@ DLLEXP bool h3dHasEmitterFinished( NodeHandle emitterNode )
 // DLL entry point
 // =================================================================================================
 
-
+#ifndef STATIC_H3D
 #ifdef PLATFORM_WIN
 BOOL APIENTRY DllMain( HANDLE /*hModule*/, DWORD /*ul_reason_for_call*/, LPVOID /*lpReserved*/ )
 {
@@ -943,4 +944,5 @@ BOOL APIENTRY DllMain( HANDLE /*hModule*/, DWORD /*ul_reason_for_call*/, LPVOID 
 	
 	return TRUE;
 }
+#endif
 #endif

--- a/Horde3D/Source/Horde3DEngine/egModel.cpp
+++ b/Horde3D/Source/Horde3DEngine/egModel.cpp
@@ -376,7 +376,7 @@ bool ModelNode::updateGeometry()
 	if( _geometryRes == 0x0 || _geometryRes->getVertPosData() == 0x0 ||
 		_geometryRes->getVertTanData() == 0x0 || _geometryRes->getVertStaticData() == 0x0 ) return false;
 	
-	Timer *timer = Modules::stats().getTimer( EngineStats::GeoUpdateTime );
+	Timer *timer = Modules::stats().getTimer( H3DStats::GeoUpdateTime );
 	if( Modules::config().gatherTimeStats ) timer->setEnabled( true );
 	
 	// Reset vertices to base data

--- a/Horde3D/Source/Horde3DEngine/egParticle.cpp
+++ b/Horde3D/Source/Horde3DEngine/egParticle.cpp
@@ -536,7 +536,7 @@ void EmitterNode::update( float timeDelta )
 	// Update absolute transformation
 	updateTree();
 	
-	Timer *timer = Modules::stats().getTimer( EngineStats::ParticleSimTime );
+	Timer *timer = Modules::stats().getTimer( H3DStats::ParticleSimTime );
 	if( Modules::config().gatherTimeStats ) timer->setEnabled( true );
 	
 	Vec3f bBMin( Math::MaxFloat, Math::MaxFloat, Math::MaxFloat );

--- a/Horde3D/Source/Horde3DEngine/egRenderer.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.cpp
@@ -192,7 +192,7 @@ bool Renderer::init()
 	finishRendering();
 
 	// Start frame timer
-	Timer *timer = Modules::stats().getTimer( EngineStats::FrameTime );
+	Timer *timer = Modules::stats().getTimer( H3DStats::FrameTime );
 	ASSERT( timer != 0x0 );
 	timer->setEnabled( true );
 	
@@ -1217,7 +1217,7 @@ void Renderer::drawLightGeometry( const string &shaderContext, const string &the
 	Modules::sceneMan().updateQueues( _curCamera->getFrustum(), 0x0, RenderingOrder::None,
 	                                  SceneNodeFlags::NoDraw, true, false );
 	
-	GPUTimer *timer = Modules::stats().getGPUTimer( EngineStats::FwdLightsGPUTime );
+	GPUTimer *timer = Modules::stats().getGPUTimer( H3DStats::FwdLightsGPUTime );
 	if( Modules::config().gatherTimeStats ) timer->beginQuery( _frameID );
 	
 	for( size_t i = 0, s = Modules::sceneMan().getLightQueue().size(); i < s; ++i )
@@ -1268,7 +1268,7 @@ void Renderer::drawLightGeometry( const string &shaderContext, const string &the
 		if( !noShadows && _curLight->_shadowMapCount > 0 )
 		{
 			timer->endQuery();
-			GPUTimer *timerShadows = Modules::stats().getGPUTimer( EngineStats::ShadowsGPUTime );
+			GPUTimer *timerShadows = Modules::stats().getGPUTimer( H3DStats::ShadowsGPUTime );
 			if( Modules::config().gatherTimeStats ) timerShadows->beginQuery( _frameID );
 
 			updateShadowMap();
@@ -1302,7 +1302,7 @@ void Renderer::drawLightGeometry( const string &shaderContext, const string &the
 		drawRenderables( shaderContext.empty() ? _curLight->_lightingContext : shaderContext,
 		                 theClass, false, &_curCamera->getFrustum(),
 		                 &_curLight->getFrustum(), order, occSet );
-		Modules().stats().incStat( EngineStats::LightPassCount, 1 );
+		Modules().stats().incStat( H3DStats::LightPassCount, 1 );
 
 		// Reset
 		gRDI->setScissorTest( false );
@@ -1328,7 +1328,7 @@ void Renderer::drawLightShapes( const string &shaderContext, bool noShadows, int
 	Modules::sceneMan().updateQueues( _curCamera->getFrustum(), 0x0, RenderingOrder::None,
 	                                  SceneNodeFlags::NoDraw, true, false );
 	
-	GPUTimer *timer = Modules::stats().getGPUTimer( EngineStats::DefLightsGPUTime );
+	GPUTimer *timer = Modules::stats().getGPUTimer( H3DStats::DefLightsGPUTime );
 	if( Modules::config().gatherTimeStats ) timer->beginQuery( _frameID );
 	
 	for( size_t i = 0, s = Modules::sceneMan().getLightQueue().size(); i < s; ++i )
@@ -1379,7 +1379,7 @@ void Renderer::drawLightShapes( const string &shaderContext, bool noShadows, int
 		if( !noShadows && _curLight->_shadowMapCount > 0 )
 		{	
 			timer->endQuery();
-			GPUTimer *timerShadows = Modules::stats().getGPUTimer( EngineStats::ShadowsGPUTime );
+			GPUTimer *timerShadows = Modules::stats().getGPUTimer( H3DStats::ShadowsGPUTime );
 			if( Modules::config().gatherTimeStats ) timerShadows->beginQuery( _frameID );
 			
 			updateShadowMap();
@@ -1423,7 +1423,7 @@ void Renderer::drawLightShapes( const string &shaderContext, bool noShadows, int
 			drawSphere( _curLight->_absPos, _curLight->_radius );
 		}
 
-		Modules().stats().incStat( EngineStats::LightPassCount, 1 );
+		Modules().stats().incStat( H3DStats::LightPassCount, 1 );
 
 		// Reset
 		gRDI->setCullMode( RS_CULL_BACK );
@@ -1662,8 +1662,8 @@ void Renderer::drawMeshes( uint32 firstItem, uint32 lastItem, const string &shad
 		// Render
 		gRDI->drawIndexed( PRIM_TRILIST, meshNode->getBatchStart(), meshNode->getBatchCount(),
 		                   meshNode->getVertRStart(), meshNode->getVertREnd() - meshNode->getVertRStart() + 1 );
-		Modules::stats().incStat( EngineStats::BatchCount, 1 );
-		Modules::stats().incStat( EngineStats::TriCount, meshNode->getBatchCount() / 3.0f );
+		Modules::stats().incStat( H3DStats::BatchCount, 1 );
+		Modules::stats().incStat( H3DStats::TriCount, meshNode->getBatchCount() / 3.0f );
 
 		if( queryObj )
 			gRDI->endQuery( queryObj );
@@ -1687,7 +1687,7 @@ void Renderer::drawParticles( uint32 firstItem, uint32 lastItem, const string &s
 	const RenderQueue &renderQueue = Modules::sceneMan().getRenderQueue();
 	MaterialResource *curMatRes = 0x0;
 
-	GPUTimer *timer = Modules::stats().getGPUTimer( EngineStats::ParticleGPUTime );
+	GPUTimer *timer = Modules::stats().getGPUTimer( H3DStats::ParticleGPUTime );
 	if( Modules::config().gatherTimeStats ) timer->beginQuery( Modules::renderer().getFrameID() );
 
 	// Bind particle geometry
@@ -1787,8 +1787,8 @@ void Renderer::drawParticles( uint32 firstItem, uint32 lastItem, const string &s
 				                      (float *)emitter->_parColors + j*ParticlesPerBatch*4, ParticlesPerBatch );
 
 			gRDI->drawIndexed( PRIM_TRILIST, 0, ParticlesPerBatch * 6, 0, ParticlesPerBatch * 4 );
-			Modules::stats().incStat( EngineStats::BatchCount, 1 );
-			Modules::stats().incStat( EngineStats::TriCount, ParticlesPerBatch * 2.0f );
+			Modules::stats().incStat( H3DStats::BatchCount, 1 );
+			Modules::stats().incStat( H3DStats::TriCount, ParticlesPerBatch * 2.0f );
 		}
 
 		uint32 count = emitter->_particleCount % ParticlesPerBatch;
@@ -1821,8 +1821,8 @@ void Renderer::drawParticles( uint32 firstItem, uint32 lastItem, const string &s
 					                      (float *)emitter->_parColors + offset*4, count );
 				
 				gRDI->drawIndexed( PRIM_TRILIST, 0, count * 6, 0, count * 4 );
-				Modules::stats().incStat( EngineStats::BatchCount, 1 );
-				Modules::stats().incStat( EngineStats::TriCount, count * 2.0f );
+				Modules::stats().incStat( H3DStats::BatchCount, 1 );
+				Modules::stats().incStat( H3DStats::TriCount, count * 2.0f );
 			}
 		}
 
@@ -1968,10 +1968,10 @@ void Renderer::finalizeFrame()
 	++_frameID;
 	
 	// Reset frame timer
-	Timer *timer = Modules::stats().getTimer( EngineStats::FrameTime );
+	Timer *timer = Modules::stats().getTimer( H3DStats::FrameTime );
 	ASSERT( timer != 0x0 );
-	Modules::stats().getStat( EngineStats::FrameTime, true );  // Reset
-	Modules::stats().incStat( EngineStats::FrameTime, timer->getElapsedTimeMS() );
+	Modules::stats().getStat( H3DStats::FrameTime, true );  // Reset
+	Modules::stats().incStat( H3DStats::FrameTime, timer->getElapsedTimeMS() );
 	timer->reset();
 }
 

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -146,7 +146,7 @@ DLLEXP bool h3dutLoadResourcesFromDisk( const char *contentDir )
 		{
 			// Find size of resource file
 			inf.seekg( 0, ios::end );
-			int fileSize = inf.tellg();
+			int fileSize = (int)inf.tellg();
 			if( bufSize < fileSize  )
 			{
 				delete[] dataBuf;				
@@ -815,6 +815,7 @@ DLLEXP bool h3dutScreenshot( const char *filename )
 // DLL entry point
 // =================================================================================================
 
+#ifndef STATIC_H3D
 #ifdef PLATFORM_WIN
 BOOL APIENTRY DllMain( HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved )
 {
@@ -835,4 +836,5 @@ BOOL APIENTRY DllMain( HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 	
 	return TRUE;
 }
+#endif
 #endif

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -36,7 +36,9 @@
 #	endif
 #endif
 
-
+#ifdef STATIC_H3D
+#	define DLLEXP extern "C"
+#else
 #ifndef DLLEXP
 #	ifdef PLATFORM_WIN
 #		define DLLEXP extern "C" __declspec( dllexport )
@@ -48,7 +50,7 @@
 #   	endif
 #	endif
 #endif
-
+#endif
 
 // Shortcuts for common types
 typedef signed char int8;


### PR DESCRIPTION
Removed EngineOptions and EngineStats structs and now uses H3DOptions and H3DStats instead (they are same, and API docs and C# uses these too).

To create and link with static libs:
- add STATIC_H3D to Horde3D,Horde3DUtils (+extensions) and your own project's
  Preprocessor settings.
- Change .dll -> .lib (Target extension and Configuration type).
- Static libs will be compiled in different directory so change paths.
  Recompile all.
