### PR TITLE
Adds STATIC_H3D flag to create static libs.

### DIFF
--- a/Horde3D/Bindings/C++/Horde3D.h
+++ b/Horde3D/Bindings/C++/Horde3D.h
@@ -14,16 +14,24 @@
 
 #pragma once
 
+#ifdef STATIC_H3D
+#	define DLL extern "C"
+#else
 #ifndef DLL
 #	if defined( WIN32 ) || defined( _WINDOWS )
-#		define DLL extern "C" __declspec( dllimport )
-#	else
-#  if defined( __GNUC__ ) && __GNUC__ >= 4
-#   define DLL extern "C" __attribute__ ((visibility("default")))
-#  else
+#		ifdef Horde3D_EXPORTS
+#			define DLL extern "C" __declspec( dllexport )
+#		else
+#			define DLL extern "C" __declspec( dllimport )
+#	    endif
+#   else
+#   if defined( __GNUC__ ) && __GNUC__ >= 4
+#       define DLL extern "C" __attribute__ ((visibility("default")))
+#   else
 #		define DLL extern "C"
-#  endif
-#	endif
+#   endif
+#   endif
+#endif
 #endif
 
 

--- a/Horde3D/Source/Horde3DEngine/egMain.cpp
+++ b/Horde3D/Source/Horde3DEngine/egMain.cpp
@@ -10,6 +10,7 @@
 //
 // *************************************************************************************************
 
+#include "Horde3D.h"
 #include "egModules.h"
 #include "egCom.h"
 #include "egExtensions.h"
@@ -147,26 +148,26 @@ DLLEXP const char *h3dGetMessage( int *level, float *time )
 }
 
 
-DLLEXP float h3dGetOption( EngineOptions::List param )
+DLLEXP float h3dGetOption( H3DOptions::List param )
 {
-	return Modules::config().getOption( param );
+	return Modules::config().getOption( (EngineOptions::List)param );
 }
 
 
-DLLEXP bool h3dSetOption( EngineOptions::List param, float value )
+DLLEXP bool h3dSetOption( H3DOptions::List param, float value )
 {
-	return Modules::config().setOption( param, value );
+	return Modules::config().setOption( (EngineOptions::List)param, value );
 }
 
 
-DLLEXP float h3dGetStat( EngineStats::List param, bool reset )
+DLLEXP float h3dGetStat( H3DStats::List param, bool reset )
 {
-	return Modules::stats().getStat( param, reset );
+	return Modules::stats().getStat( (EngineOptions::List)param, reset );
 }
 
 
 DLLEXP void h3dShowOverlays( const float *verts, int vertCount, float colR, float colG,
-                             float colB, float colA, uint32 materialRes, int flags )
+                             float colB, float colA, H3DRes materialRes, int flags )
 {
 	Resource *resObj = Modules::resMan().resolveResHandle( materialRes ); 
 	APIFUNC_VALIDATE_RES_TYPE( resObj, ResourceTypes::Material, "h3dShowOverlays", APIFUNC_RET_VOID );
@@ -926,6 +927,7 @@ DLLEXP bool h3dHasEmitterFinished( NodeHandle emitterNode )
 // =================================================================================================
 
 
+#ifndef STATIC_H3D
 #ifdef PLATFORM_WIN
 BOOL APIENTRY DllMain( HANDLE /*hModule*/, DWORD /*ul_reason_for_call*/, LPVOID /*lpReserved*/ )
 {
@@ -943,4 +945,5 @@ BOOL APIENTRY DllMain( HANDLE /*hModule*/, DWORD /*ul_reason_for_call*/, LPVOID 
 	
 	return TRUE;
 }
+#endif
 #endif

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -815,6 +815,7 @@ DLLEXP bool h3dutScreenshot( const char *filename )
 // DLL entry point
 // =================================================================================================
 
+#ifndef STATIC_H3D
 #ifdef PLATFORM_WIN
 BOOL APIENTRY DllMain( HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved )
 {
@@ -835,4 +836,5 @@ BOOL APIENTRY DllMain( HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 	
 	return TRUE;
 }
+#endif
 #endif

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -37,6 +37,9 @@
 #endif
 
 
+#ifdef STATIC_H3D
+#	define DLLEXP extern "C"
+#else
 #ifndef DLLEXP
 #	ifdef PLATFORM_WIN
 #		define DLLEXP extern "C" __declspec( dllexport )
@@ -47,6 +50,7 @@
 #		  define DLLEXP extern "C"
 #   	endif
 #	endif
+#endif
 #endif
 
 


### PR DESCRIPTION
To create and link with static libs (VS):
* add STATIC_H3D to Horde3D,Horde3DUtils and your own project's Preprocessor settings.
* Change .dll -> .lib (Target extension and Configuration type).
* Static libs will be compiled in different directory so change paths.
* Recompile all.