### PR TITLE
Initial support for endian-independent resource loading.

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -13,7 +13,6 @@
 #include "egAnimation.h"
 #include "egModules.h"
 #include "egCom.h"
-#include <cstring>
 #include <algorithm>
 
 #include "utDebug.h"
@@ -98,14 +97,14 @@ bool AnimationResource::load( const char *data, int size )
 		return raiseError( "Invalid animation resource" );
 	
 	uint32 version;
-	memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 	if( version != 2 && version != 3 )
 		return raiseError( "Unsupported version of animation resource" );
 	
 	// Load animation data
 	uint32 numEntities;
-	memcpy( &numEntities, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-	memcpy( &_numFrames, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &numEntities, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &_numFrames, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 
 	_entities.resize( numEntities );
 
@@ -128,18 +127,18 @@ bool AnimationResource::load( const char *data, int size )
 		{
 			Frame &frame = entity.frames[j];
 
-			memcpy( &frame.rotQuat.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.z, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.w, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.rotQuat.x, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.rotQuat.y, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.rotQuat.z, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.rotQuat.w, pData, sizeof( float ) ); pData += sizeof( float );
 
-			memcpy( &frame.transVec.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.transVec.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.transVec.z, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.transVec.x, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.transVec.y, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.transVec.z, pData, sizeof( float ) ); pData += sizeof( float );
 
-			memcpy( &frame.scaleVec.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.scaleVec.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.scaleVec.z, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.scaleVec.x, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.scaleVec.y, pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &frame.scaleVec.z, pData, sizeof( float ) ); pData += sizeof( float );
 
 			// Prebake transformation matrix for fast animation path
 			frame.bakedTransMat.scale( frame.scaleVec.x, frame.scaleVec.y, frame.scaleVec.z );

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -370,7 +370,7 @@ bool GeometryResource::load( const char *data, int size )
 		MorphTarget &mt = _morphTargets[i];
 		char name[256];
 		
-		endianless_memcpy( name, pData, 256 ); pData += 256;
+		memcpy( name, pData, 256 ); pData += 256;
 		mt.name = name;
 		
 		// Read vertex indices

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -16,7 +16,6 @@
 #include "egModules.h"
 #include "egCom.h"
 #include "egRenderer.h"
-#include <cstring>
 
 #include "utDebug.h"
 
@@ -163,12 +162,12 @@ bool GeometryResource::load( const char *data, int size )
 		return raiseError( "Invalid geometry resource" );
 
 	uint32 version;
-	memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 	if( version != 5 ) return raiseError( "Unsupported version of geometry file" );
 
 	// Load joints
 	uint32 count;
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 
 	if( count > 75 )
 		Modules::log().writeWarning( "Geometry resource '%s': Model has more than 75 joints; this may cause defective behavior", _name.c_str() );
@@ -181,14 +180,14 @@ bool GeometryResource::load( const char *data, int size )
 		// Inverse bind matrix
 		for( uint32 j = 0; j < 16; ++j )
 		{
-			memcpy( &joint.invBindMat.x[j], pData, sizeof( float ) ); pData += sizeof( float );
+			endianless_memcpy( &joint.invBindMat.x[j], pData, sizeof( float ) ); pData += sizeof( float );
 		}
 	}
 	
 	// Load vertex stream data
 	uint32 streamSize;
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );			// Number of streams
-	memcpy( &streamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );	// Number of vertices
+	endianless_memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );			// Number of streams
+	endianless_memcpy( &streamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );	// Number of vertices
 
 	_vertCount = streamSize;
 	_vertPosData = new Vec3f[_vertCount];
@@ -207,8 +206,8 @@ bool GeometryResource::load( const char *data, int size )
 		unsigned char uc;
 		short sh;
 		uint32 streamID, streamElemSize;
-		memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-		memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		endianless_memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		endianless_memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 		std::string errormsg;
 
 		switch( streamID )
@@ -221,9 +220,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertPosData[j].x, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertPosData[j].y, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertPosData[j].z, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertPosData[j].x, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertPosData[j].y, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertPosData[j].z, pData, sizeof( float ) ); pData += sizeof( float );
 			}
 			break;
 		case 1:		// Normal
@@ -234,9 +233,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.z = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.x = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.y = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.z = sh / 32767.0f;
 			}
 			break;
 		case 2:		// Tangent
@@ -247,9 +246,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.z = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.x = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.y = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.z = sh / 32767.0f;
 			}
 			break;
 		case 3:		// Bitangent
@@ -260,9 +259,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].z = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].x = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].y = sh / 32767.0f;
+				endianless_memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].z = sh / 32767.0f;
 			}
 			break;
 		case 4:		// Joint indices
@@ -301,8 +300,8 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertStaticData[j].u0, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertStaticData[j].v0, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertStaticData[j].u0, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertStaticData[j].v0, pData, sizeof( float ) ); pData += sizeof( float );
 			}
 			break;
 		case 7:		// Texture Coord Set 2
@@ -313,8 +312,8 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertStaticData[j].u1, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertStaticData[j].v1, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertStaticData[j].u1, pData, sizeof( float ) ); pData += sizeof( float );
+				endianless_memcpy( &_vertStaticData[j].v1, pData, sizeof( float ) ); pData += sizeof( float );
 			}
 			break;
 		default:
@@ -337,7 +336,7 @@ bool GeometryResource::load( const char *data, int size )
 	delete[] bitangents;
 		
 	// Load triangle indices
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 
 	_indexCount = count;
     _16BitIndices = _vertCount <= 65536;
@@ -348,7 +347,7 @@ bool GeometryResource::load( const char *data, int size )
 		uint16 *pIndexData = (uint16 *)_indexData;
 		for( uint32 i = 0; i < count; ++i )
 		{
-			memcpy( &index, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			endianless_memcpy( &index, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 			pIndexData[i] = (uint16)index;
 		}
 	}
@@ -357,13 +356,13 @@ bool GeometryResource::load( const char *data, int size )
 		uint32 *pIndexData = (uint32 *)_indexData;
 		for( uint32 i = 0; i < count; ++i )
 		{
-			memcpy( &pIndexData[i], pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			endianless_memcpy( &pIndexData[i], pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 		}
 	}
 
 	// Load morph targets
 	uint32 numTargets;
-	memcpy( &numTargets, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	endianless_memcpy( &numTargets, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 
 	_morphTargets.resize( numTargets );
 	for( uint32 i = 0; i < numTargets; ++i )
@@ -371,25 +370,25 @@ bool GeometryResource::load( const char *data, int size )
 		MorphTarget &mt = _morphTargets[i];
 		char name[256];
 		
-		memcpy( name, pData, 256 ); pData += 256;
+		endianless_memcpy( name, pData, 256 ); pData += 256;
 		mt.name = name;
 		
 		// Read vertex indices
 		uint32 morphStreamSize;
-		memcpy( &morphStreamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		endianless_memcpy( &morphStreamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 		mt.diffs.resize( morphStreamSize );
 		for( uint32 j = 0; j < morphStreamSize; ++j )
 		{
-			memcpy( &mt.diffs[j].vertIndex, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			endianless_memcpy( &mt.diffs[j].vertIndex, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 		}
 		
 		// Loop over streams
-		memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		endianless_memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 		for( uint32 j = 0; j < count; ++j )
 		{
 			uint32 streamID, streamElemSize;
-			memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-			memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			endianless_memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			endianless_memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
 
 			switch( streamID )
 			{
@@ -397,27 +396,27 @@ bool GeometryResource::load( const char *data, int size )
 				if( streamElemSize != 12 ) return raiseError( "Invalid position morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].posDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].posDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].posDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].posDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].posDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].posDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
 				}
 				break;
 			case 1:		// Normal
 				if( streamElemSize != 12 ) return raiseError( "Invalid normal morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].normDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].normDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].normDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].normDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].normDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].normDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
 				}
 				break;
 			case 2:		// Tangent
 				if( streamElemSize != 12 ) return raiseError( "Invalid tangent morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].tanDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].tanDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].tanDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].tanDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].tanDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
+					endianless_memcpy( &mt.diffs[k].tanDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
 				}
 				break;
 			case 3:		// Bitangent

--- a/Horde3D/Source/Horde3DEngine/egModel.cpp
+++ b/Horde3D/Source/Horde3DEngine/egModel.cpp
@@ -15,7 +15,6 @@
 #include "egModules.h"
 #include "egRenderer.h"
 #include "egCom.h"
-#include <cstring>
 
 #include "utDebug.h"
 
@@ -380,10 +379,12 @@ bool ModelNode::updateGeometry()
 	if( Modules::config().gatherTimeStats ) timer->setEnabled( true );
 	
 	// Reset vertices to base data
-	memcpy( _geometryRes->getVertPosData(), _baseGeoRes->getVertPosData(),
-	        _geometryRes->_vertCount * sizeof( Vec3f ) );
-	memcpy( _geometryRes->getVertTanData(), _baseGeoRes->getVertTanData(),
-	        _geometryRes->_vertCount * sizeof( VertexDataTan ) );
+	endianless_memcpy( _geometryRes->getVertPosData(),
+        _baseGeoRes->getVertPosData(),
+        _geometryRes->_vertCount * sizeof( Vec3f ) );
+	endianless_memcpy( _geometryRes->getVertTanData(),
+        _baseGeoRes->getVertTanData(),
+        _geometryRes->_vertCount * sizeof( VertexDataTan ) );
 
 	Vec3f *posData = _geometryRes->getVertPosData();
 	VertexDataTan *tanData = _geometryRes->getVertTanData();

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -13,6 +13,8 @@
 #ifndef _utPlatform_H_
 #define _utPlatform_H_
 
+#include <cstring>
+
 #if defined( _DEBUG )
 	#include <assert.h>
 #endif
@@ -57,7 +59,6 @@ typedef unsigned int uint32;
 typedef long long int64;
 typedef unsigned long long uint64;
 
-
 #if !defined( PLATFORM_WIN ) && !defined( PLATFORM_WIN_CE )
 #	define _stricmp strcasecmp
 #	define _mkdir( name ) mkdir( name, 0755 )
@@ -81,6 +82,34 @@ typedef unsigned long long uint64;
 #   define vsnprintf _vsnprintf
 #endif
 
+// Utils to handle endianness
+const int bsti = 1;  // Byte swap test integer
+#define is_littleendian() ( (*(char*)&bsti) != 0 )
+
+static void endianless( void* src, size_t size )
+{
+    unsigned char* start;
+    unsigned char* end;
+
+    if ( !is_littleendian() )
+    {
+        for ( start = (unsigned char*)src, end = start + size - 1; start < end; ++start, --end )
+        {
+           unsigned char swap = *start;
+           *start = *end;
+           *end = swap;
+        }
+    }
+}
+
+static void* endianless_memcpy( void* dest, const void* src, size_t count )
+{
+    memcpy( dest, src, count );
+
+    endianless( dest, count );
+
+    return dest;
+}
 
 // Runtime assertion
 #if defined( _DEBUG )


### PR DESCRIPTION
Added initial support for endian-independent resource loading. It should fix #25.

Please, test it on big-endian machines!