### PR TITLE
Add LGPL dual license.

### DIFF
--- a/Extensions/Terrain/Bindings/C++/Horde3DTerrain.h
+++ b/Extensions/Terrain/Bindings/C++/Horde3DTerrain.h
@@ -4,8 +4,13 @@
 // --------------------------------------------------------
 // Copyright (C) 2006-2009 Nicolas Schulz and Volker Wiendl
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Extensions/Terrain/Sample/app.cpp
+++ b/Extensions/Terrain/Sample/app.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Extensions/Terrain/Sample/app.h
+++ b/Extensions/Terrain/Sample/app.h
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Extensions/Terrain/Sample/main.cpp
+++ b/Extensions/Terrain/Sample/main.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Extensions/Terrain/Source/extension.cpp
+++ b/Extensions/Terrain/Source/extension.cpp
@@ -4,8 +4,13 @@
 // --------------------------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz and Volker Wiendl
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Extensions/Terrain/Source/extension.h
+++ b/Extensions/Terrain/Source/extension.h
@@ -4,8 +4,13 @@
 // --------------------------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz and Volker Wiendl
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Extensions/Terrain/Source/terrain.cpp
+++ b/Extensions/Terrain/Source/terrain.cpp
@@ -4,8 +4,13 @@
 // --------------------------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz and Volker Wiendl
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Extensions/Terrain/Source/terrain.h
+++ b/Extensions/Terrain/Source/terrain.h
@@ -4,8 +4,13 @@
 // --------------------------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz and Volker Wiendl
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3D.cs
+++ b/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3D.cs
@@ -6,8 +6,13 @@
 // Copyright (C) 2009 Volker Wiendl
 //
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3DUtils.cs
+++ b/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3DUtils.cs
@@ -6,8 +6,13 @@
 // Copyright (C) 2009 Volker Wiendl
 //
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 using System;

--- a/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3DUtils_Import.cs
+++ b/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3DUtils_Import.cs
@@ -6,8 +6,13 @@
 // Copyright (C) 2009 Volker Wiendl
 //
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3D_Import.cs
+++ b/Horde3D/Bindings/C#/Source/Horde3D .NET/Horde3D_Import.cs
@@ -6,8 +6,13 @@
 // Copyright (C) 2009 Volker Wiendl
 //
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/App.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/App.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/CrowdSim.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/CrowdSim.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Input.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Input.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Program.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Program.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Properties/AssemblyInfo.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the LGPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/RenderForm.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/RenderForm.cs
@@ -5,7 +5,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/RenderForm.designer.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Chicago .NET/RenderForm.designer.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the LGPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/App.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/App.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Input.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Input.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Program.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Program.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Properties/AssemblyInfo.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the LGPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/RenderForm.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/RenderForm.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the EPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/Source/Samples/Knight .NET/RenderForm.designer.cs
+++ b/Horde3D/Bindings/C#/Source/Samples/Knight .NET/RenderForm.designer.cs
@@ -7,7 +7,7 @@
 //
 // This file is intended for use as a code example, and may be used, modified, 
 // or distributed in source or object code form, without restriction. 
-// This sample is not covered by the LGPL.
+// This sample is not covered by the EPL or LGPL.
 //
 // The code and information is provided "as-is" without warranty of any kind, 
 // either expressed or implied.

--- a/Horde3D/Bindings/C#/license-lgpl.txt
+++ b/Horde3D/Bindings/C#/license-lgpl.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Horde3D/Bindings/C++/Horde3D.h
+++ b/Horde3D/Bindings/C++/Horde3D.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2009 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Bindings/C++/Horde3DUtils.h
+++ b/Horde3D/Bindings/C++/Horde3DUtils.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2009 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Docs/html/_faq.html
+++ b/Horde3D/Docs/html/_faq.html
@@ -43,7 +43,7 @@ in next-generation quality.
 <a id="License"></a>
 <h3>Under which license is Horde3D distributed?</h3>
 <p>
-Horde3D is distributed under the terms of the Eclipse Public License.
+Horde3D is dual-licensed under the terms of the Eclipse Public License and the GNU Lesser General Public License.
 See the <a href="http://www.horde3d.org/license.html">licensing site</a> for more information.
 </p>
 

--- a/Horde3D/Samples/Chicago/app.cpp
+++ b/Horde3D/Samples/Chicago/app.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Chicago/app.h
+++ b/Horde3D/Samples/Chicago/app.h
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Chicago/crowd.cpp
+++ b/Horde3D/Samples/Chicago/crowd.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Chicago/crowd.h
+++ b/Horde3D/Samples/Chicago/crowd.h
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Chicago/main.cpp
+++ b/Horde3D/Samples/Chicago/main.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Knight/app.cpp
+++ b/Horde3D/Samples/Knight/app.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Knight/app.h
+++ b/Horde3D/Samples/Knight/app.h
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Samples/Knight/main.cpp
+++ b/Horde3D/Samples/Knight/main.cpp
@@ -8,8 +8,8 @@
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
 //
-// This sample source file is not covered by the EPL as the rest of the SDK
-// and may be used without any restrictions. However, the EPL's disclaimer of
+// This sample source file is not covered by the EPL or LGPL as the rest of the SDK
+// and may be used without any restrictions. However, the EPL's or LGPL's disclaimer of
 // warranty and liability shall be in effect for this file.
 //
 // *************************************************************************************************

--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/converter.h
+++ b/Horde3D/Source/ColladaConverter/converter.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeCommon.h
+++ b/Horde3D/Source/ColladaConverter/daeCommon.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibAnimations.h
+++ b/Horde3D/Source/ColladaConverter/daeLibAnimations.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibControllers.h
+++ b/Horde3D/Source/ColladaConverter/daeLibControllers.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibEffects.h
+++ b/Horde3D/Source/ColladaConverter/daeLibEffects.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibGeometries.h
+++ b/Horde3D/Source/ColladaConverter/daeLibGeometries.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibImages.h
+++ b/Horde3D/Source/ColladaConverter/daeLibImages.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibMaterials.h
+++ b/Horde3D/Source/ColladaConverter/daeLibMaterials.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibNodes.h
+++ b/Horde3D/Source/ColladaConverter/daeLibNodes.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeLibVisualScenes.h
+++ b/Horde3D/Source/ColladaConverter/daeLibVisualScenes.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeMain.cpp
+++ b/Horde3D/Source/ColladaConverter/daeMain.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/daeMain.h
+++ b/Horde3D/Source/ColladaConverter/daeMain.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/main.cpp
+++ b/Horde3D/Source/ColladaConverter/main.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/optimizer.cpp
+++ b/Horde3D/Source/ColladaConverter/optimizer.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/optimizer.h
+++ b/Horde3D/Source/ColladaConverter/optimizer.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/utils.cpp
+++ b/Horde3D/Source/ColladaConverter/utils.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/ColladaConverter/utils.h
+++ b/Horde3D/Source/ColladaConverter/utils.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/config.h
+++ b/Horde3D/Source/Horde3DEngine/config.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egAnimatables.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimatables.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egAnimatables.h
+++ b/Horde3D/Source/Horde3DEngine/egAnimatables.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egAnimation.h
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egCamera.cpp
+++ b/Horde3D/Source/Horde3DEngine/egCamera.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egCamera.h
+++ b/Horde3D/Source/Horde3DEngine/egCamera.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egCom.cpp
+++ b/Horde3D/Source/Horde3DEngine/egCom.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egCom.h
+++ b/Horde3D/Source/Horde3DEngine/egCom.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egExtensions.cpp
+++ b/Horde3D/Source/Horde3DEngine/egExtensions.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egExtensions.h
+++ b/Horde3D/Source/Horde3DEngine/egExtensions.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egGeometry.h
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egLight.cpp
+++ b/Horde3D/Source/Horde3DEngine/egLight.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egLight.h
+++ b/Horde3D/Source/Horde3DEngine/egLight.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egMain.cpp
+++ b/Horde3D/Source/Horde3DEngine/egMain.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egMaterial.cpp
+++ b/Horde3D/Source/Horde3DEngine/egMaterial.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egMaterial.h
+++ b/Horde3D/Source/Horde3DEngine/egMaterial.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egModel.cpp
+++ b/Horde3D/Source/Horde3DEngine/egModel.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egModel.h
+++ b/Horde3D/Source/Horde3DEngine/egModel.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egModules.cpp
+++ b/Horde3D/Source/Horde3DEngine/egModules.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egModules.h
+++ b/Horde3D/Source/Horde3DEngine/egModules.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egParticle.cpp
+++ b/Horde3D/Source/Horde3DEngine/egParticle.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egParticle.h
+++ b/Horde3D/Source/Horde3DEngine/egParticle.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egPipeline.cpp
+++ b/Horde3D/Source/Horde3DEngine/egPipeline.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egPipeline.h
+++ b/Horde3D/Source/Horde3DEngine/egPipeline.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egPrerequisites.h
+++ b/Horde3D/Source/Horde3DEngine/egPrerequisites.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egPrimitives.cpp
+++ b/Horde3D/Source/Horde3DEngine/egPrimitives.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egPrimitives.h
+++ b/Horde3D/Source/Horde3DEngine/egPrimitives.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egRenderer.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egRenderer.h
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBase.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBase.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBase.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBase.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egResource.cpp
+++ b/Horde3D/Source/Horde3DEngine/egResource.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egResource.h
+++ b/Horde3D/Source/Horde3DEngine/egResource.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egScene.cpp
+++ b/Horde3D/Source/Horde3DEngine/egScene.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egScene.h
+++ b/Horde3D/Source/Horde3DEngine/egScene.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egSceneGraphRes.cpp
+++ b/Horde3D/Source/Horde3DEngine/egSceneGraphRes.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egSceneGraphRes.h
+++ b/Horde3D/Source/Horde3DEngine/egSceneGraphRes.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egShader.cpp
+++ b/Horde3D/Source/Horde3DEngine/egShader.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egShader.h
+++ b/Horde3D/Source/Horde3DEngine/egShader.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egTexture.cpp
+++ b/Horde3D/Source/Horde3DEngine/egTexture.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/egTexture.h
+++ b/Horde3D/Source/Horde3DEngine/egTexture.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/utImage.cpp
+++ b/Horde3D/Source/Horde3DEngine/utImage.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/utImage.h
+++ b/Horde3D/Source/Horde3DEngine/utImage.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
+++ b/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/utOpenGL.h
+++ b/Horde3D/Source/Horde3DEngine/utOpenGL.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DEngine/utTimer.h
+++ b/Horde3D/Source/Horde3DEngine/utTimer.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Shared/utDebug.h
+++ b/Horde3D/Source/Shared/utDebug.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Shared/utMath.h
+++ b/Horde3D/Source/Shared/utMath.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/Source/Shared/utXML.h
+++ b/Horde3D/Source/Shared/utXML.h
@@ -5,8 +5,13 @@
 // --------------------------------------
 // Copyright (C) 2006-2011 Nicolas Schulz
 //
-// This software is distributed under the terms of the Eclipse Public License v1.0.
-// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+// This software is dual licensed under either the terms of the Eclipse Public License v1.0,
+// a copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html,
+//
+//    or (per the licensee's choosing)
+//
+// under the terms of the GNU Lesser General Public License, a copy of the license
+// may be obtained at: http://www.gnu.org/licenses/lgpl.html.
 //
 // *************************************************************************************************
 

--- a/Horde3D/license-lgpl.txt
+++ b/Horde3D/license-lgpl.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Here are some quick links to help you get started:
 
 ## License
 
-Horde3D is licensed under the [Eclipse Public License v1.0 (EPL)](http://www.eclipse.org/legal/epl-v10.html).
+Horde3D is dual-licensed under the [Eclipse Public License v1.0 (EPL)](http://www.eclipse.org/legal/epl-v10.html) and the [GNU Lesser General Public License v3 (LGPLv3)](http://www.gnu.org/licenses/lgpl.html) as per the licensee's choosing.
 
-The EPL is a quite liberal license and has fewer restrictions than the popular LGPL. Basically it allows you to use Horde3D in free and commercial projects as long as you contribute improvements like bug fixes, optimizations and code refactorings back to the community. The EPL allows static linking and is not viral; hence it does not affect any other modules of your application.
+The EPL is a quite liberal license and has fewer restrictions than the popular LGPL. Basically it allows you to use Horde3D in free and commercial projects as long as you contribute improvements like bug fixes, optimizations and code refactorings back to the community. The EPL allows static linking and is not viral; hence it does not affect any other modules of your application. However, the EPL is not compatible with the GPL license. The LGPL license is offered as an alternative for developers that wish to link to GPL software.


### PR DESCRIPTION
I've run in to a situation where I'd like to use Horde3D in a project, but another dependency is licensed under the GPL. The EPL which Horde3d is licensed under is incompatible with the GPL which prevents me from using Horde3D in my project. I brought this up with Volker, citing this old topic in the forums: http://www.horde3d.org/forums/viewtopic.php?f=1&t=744&hilit=gpl&start=90, asking if Horde3D could see a GPL compatible license. He suggested I create an LGPL dual license patch.

I used LogBack (http://logback.qos.ch/license.html) as a reference for the language used to communicate the dual license.

The website page: http://www.horde3d.org/license.html would also need to be updated to reflect this change.
