### PR TITLE
Fix sample not running on VS 2013 due to h3dGetResName() bug

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egResource.h
+++ b/Horde3D/Source/Horde3DEngine/egResource.h
@@ -84,7 +84,7 @@ public:
 
 	int getType() const { return _type; }
 	int getFlags() const { return _flags; }
-	const std::string getName() const { return _name; }
+	const std::string &getName() const { return _name; }
 	ResHandle getHandle() const { return _handle; }
 	bool isLoaded() const { return _loaded; }
 	void addRef() { ++_refCount; }


### PR DESCRIPTION
Resource::getName() returned a std::string by value. h3dGetResName() returned the .c_str() of that temporary std::string, which is destroyed as soon as h3dGetResName() is existed.

In practice, path used to load resources ended with some garbage characters at the end, causing load to fail.

This used to "work" because std::string char buffer was always dynamically allocated and had copy on write semantic. This is no longer the case in recent version of Visual Studio.

Stumbled on this when trying to run the sample...