### PR TITLE
Safe Geometry Map/Unmap & HORDE3D_BUILD_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,19 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake/Modules/" ${CMAKE_MODULE_PATH})
 include(CheckFunctionExists)
 check_function_exists(strncpy_s HAVE_STRNCPY_S)
 
+# To build or not to build examples (removes GLFW dependency)
+option(HORDE3D_BUILD_EXAMPLES "Builds Horde3D examples" ON)
+
 # Look for required GLFW library.
-option(HORDE3D_FORCE_DOWNLOAD_GLFW "Force linking Horde3D to a downloaded version of GLFW" OFF)
-find_package(GLFW)
-IF(GLFW_FOUND)
-    include_directories(${GLFW_INCLUDE_DIR})
-ENDIF(GLFW_FOUND)
+if(HORDE3D_BUILD_EXAMPLES)
+    option(HORDE3D_FORCE_DOWNLOAD_GLFW "Force linking Horde3D to a downloaded version of GLFW" OFF)
+    find_package(GLFW)
+    IF(GLFW_FOUND)
+        include_directories(${GLFW_INCLUDE_DIR})
+    ENDIF(GLFW_FOUND)
+else()
+    message("Not building examples.")
+endif(HORDE3D_BUILD_EXAMPLES)
 
 # Set binaries output folder.
 SET(HORDE3D_OUTPUT_PATH_PREFIX "${PROJECT_BINARY_DIR}/Binaries")

--- a/Horde3D/CMakeLists.txt
+++ b/Horde3D/CMakeLists.txt
@@ -1,5 +1,7 @@
 
 add_subdirectory(Source)
-add_subdirectory(Samples)
+if(HORDE3D_BUILD_EXAMPLES)
+    add_subdirectory(Samples)
+endif(HORDE3D_BUILD_EXAMPLES)
 add_subdirectory(Bindings)
 add_subdirectory(Binaries)

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -519,10 +519,8 @@ int GeometryResource::getElemParamI( int elem, int elemIdx, int param ) const
 
 void *GeometryResource::mapStream( int elem, int elemIdx, int stream, bool read, bool write )
 {
-	if( read || write )
+	if( (read || write) && mappedWriteStream == -1 )
 	{
-		mappedWriteStream = -1;
-		
 		switch( elem )
 		{
 		case GeometryResData::GeometryElem:
@@ -550,7 +548,7 @@ void *GeometryResource::mapStream( int elem, int elemIdx, int stream, bool read,
 
 void GeometryResource::unmapStream()
 {
-	if( mappedWriteStream )
+	if( mappedWriteStream >= 0 )
 	{
 		switch( mappedWriteStream )
 		{


### PR DESCRIPTION
* There seems to be some miscoding in the geometry `mapStream` / `unmapStream`, unlike `egTexture.cpp` the geometry version doesn't safely check if there's a write mapping still out there before mapping. Also the unmapper was checking for `0` instead of `-1`.
* Added `HORDE3D_BUILD_EXAMPLES` as CMake option which disables the need to have glfw as a dependency.