### PR TITLE
Endian-independent resource loading

### DIFF
--- a/Extensions/Terrain/Source/terrain.cpp
+++ b/Extensions/Terrain/Source/terrain.cpp
@@ -911,19 +911,19 @@ ResHandle TerrainNode::createGeometryResource( const string &name, float lodThre
     // Write Horde flag
     pData = elemcpyd_le((char*)(pData), "H3DG", 4);
 	// Set version to 5
-	pData = elemset_le<uint32>((uint32 *)(pData), 5);
+	pData = elemset_le((uint32 *)(pData), 5u);
 	// Set joint count (zero for terrains)
-	pData = elemset_le<uint32>((uint32 *)(pData), 0);
+	pData = elemset_le((uint32 *)(pData), 0u);
 	// Set number of streams
-	pData = elemset_le<uint32>((uint32 *)(pData), 1);
+	pData = elemset_le((uint32 *)(pData), 1u);
 	// Write size of each stream
-	pData = elemset_le<uint32>((uint32 *)(pData), streamSize);
+	pData = elemset_le((uint32 *)(pData), streamSize);
 	
 	// Beginning of stream data
 	// Stream ID
-	pData = elemset_le<uint32>((uint32 *)(pData), 0);
+	pData = elemset_le((uint32 *)(pData), 0u);
 	// set stream element size
-	pData = elemset_le<uint32>((uint32 *)(pData), streamElementSize);
+	pData = elemset_le((uint32 *)(pData), streamElementSize);
 
 	uint32 index = 0;
 	float *vertexData = (float *)pData;
@@ -936,13 +936,13 @@ ResHandle TerrainNode::createGeometryResource( const string &name, float lodThre
 	pData += streamSize * streamElementSize;
 
 	// Set number of indices
-	pData = elemset_le<uint32>((uint32 *)(pData), indexCount);
+	pData = elemset_le((uint32 *)(pData), indexCount);
 	
 	// Skip index data
 	pData += indexCount * sizeof( uint32 );				
 
 	// Set number of morph targets
-    pData = elemset_le<uint32>((uint32 *)(pData), 0);
+    pData = elemset_le((uint32 *)(pData), 0u);
 
 	ResHandle res = Modules::resMan().addResource( ResourceTypes::Geometry, name, 0, true );
 	resObj = Modules::resMan().resolveResHandle( res );

--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -32,7 +32,7 @@ template<class T>
 inline void fwrite_le(const T* data, size_t count, FILE* f)
 {
     char buffer[256];
-    ASSERT(sizeof(T) > sizeof(buffer));
+    ASSERT(sizeof(T) < sizeof(buffer));
     const size_t capacity = sizeof(buffer) / sizeof(T);
 
     size_t i = 0;

--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -19,12 +19,31 @@
 #include "converter.h"
 #include "optimizer.h"
 #include "utPlatform.h"
+#include "utEndian.h"
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 
 using namespace std;
 
+// little endian element writer
+template<class T>
+inline void fwrite_le(const T* data, size_t count, FILE* f)
+{
+    char buffer[256];
+    ASSERT(sizeof(T) > sizeof(buffer));
+    const size_t capacity = sizeof(buffer) / sizeof(T);
+
+    size_t i = 0;
+    while(i < count)
+    {
+        size_t nelems = std::min(capacity, (count - i));
+        data = (const T*) elemcpy_le((T*)(buffer), data, nelems);
+        fwrite(buffer, sizeof(T), nelems, f);
+        i += nelems;
+    }
+}
 
 Converter::Converter( ColladaDocument &doc, const string &outPath, float *lodDists ) :
 	_daeDoc( doc )
@@ -882,31 +901,31 @@ bool Converter::writeGeometry( const string &assetPath, const string &assetName 
 
 	// Write header
 	unsigned int version = 5;
-	fwrite( "H3DG", 4, 1, f );
-	fwrite( &version, sizeof( int ), 1, f ); 
+	fwrite_le("H3DG", 4, f);
+	fwrite_le(&version, 1, f); 
 	
 	// Write joints
 	unsigned int count = (unsigned int)_joints.size() + 1;
-	fwrite( &count, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
 
 	// Write default identity matrix
 	for( unsigned int j = 0; j < 16; ++j )
-		fwrite( &Matrix4f().x[j], sizeof( float ), 1, f );
+		fwrite_le<float>(&Matrix4f().x[j], 1, f);
 
 	for( unsigned int i = 0; i < _joints.size(); ++i )
 	{
 		// Inverse bind matrix
 		for( unsigned int j = 0; j < 16; ++j )
 		{
-			fwrite( &_joints[i]->invBindMat.x[j], sizeof( float ), 1, f );
+			fwrite_le<float>(&_joints[i]->invBindMat.x[j], 1, f);
 		}
 	}
 	
 	// Write vertex stream data
 	if( _joints.empty() ) count = 6; else count = 8;	// Number of streams
-	fwrite( &count, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
 	count = (unsigned int)_vertices.size();
-	fwrite( &count, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
 
 	for( unsigned int i = 0; i < 8; ++i )
 	{
@@ -919,48 +938,48 @@ bool Converter::writeGeometry( const string &assetPath, const string &assetName 
 		switch( i )
 		{
 		case 0:		// Position
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 3 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 3 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				fwrite( &_vertices[j].pos.x, sizeof( float ), 1, f );
-				fwrite( &_vertices[j].pos.y, sizeof( float ), 1, f );
-				fwrite( &_vertices[j].pos.z, sizeof( float ), 1, f );
+				fwrite_le<float>(&_vertices[j].pos.x, 1, f);
+				fwrite_le<float>(&_vertices[j].pos.y, 1, f);
+				fwrite_le<float>(&_vertices[j].pos.z, 1, f);
 			}
 			break;
 		case 1:		// Normal
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 3 * sizeof( short ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 3 * sizeof( short ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				sh = (short)(_vertices[j].normal.x * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].normal.y * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].normal.z * 32767); fwrite( &sh, sizeof( short ), 1, f );
+				sh = (short)(_vertices[j].normal.x * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].normal.y * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].normal.z * 32767); fwrite_le<short>(&sh, 1, f);
 			}
 			break;
 		case 2:		// Tangent
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 3 * sizeof( short ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 3 * sizeof( short ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				sh = (short)(_vertices[j].tangent.x * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].tangent.y * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].tangent.z * 32767); fwrite( &sh, sizeof( short ), 1, f );
+				sh = (short)(_vertices[j].tangent.x * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].tangent.y * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].tangent.z * 32767); fwrite_le<short>(&sh, 1, f);
 			}
 			break;
 		case 3:		// Bitangent
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 3 * sizeof( short ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 3 * sizeof( short ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				sh = (short)(_vertices[j].bitangent.x * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].bitangent.y * 32767); fwrite( &sh, sizeof( short ), 1, f );
-				sh = (short)(_vertices[j].bitangent.z * 32767); fwrite( &sh, sizeof( short ), 1, f );
+				sh = (short)(_vertices[j].bitangent.x * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].bitangent.y * 32767); fwrite_le<short>(&sh, 1, f);
+				sh = (short)(_vertices[j].bitangent.z * 32767); fwrite_le<short>(&sh, 1, f);
 			}
 			break;
 		case 4:		// Joint indices
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 4 * sizeof( char ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 4 * sizeof( char ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
 				unsigned char jointIndices[4] = { 0, 0, 0, 0 };
@@ -972,39 +991,39 @@ bool Converter::writeGeometry( const string &assetPath, const string &assetName 
 					jointIndices[2] = (unsigned char)_vertices[j].joints[2]->index;
 				if( _vertices[j].joints[3] != 0x0 )
 					jointIndices[3] = (unsigned char)_vertices[j].joints[3]->index;
-				fwrite( &jointIndices[0], sizeof( char ), 1, f );
-				fwrite( &jointIndices[1], sizeof( char ), 1, f );
-				fwrite( &jointIndices[2], sizeof( char ), 1, f );
-				fwrite( &jointIndices[3], sizeof( char ), 1, f );
+				fwrite_le(&jointIndices[0], 1, f);
+				fwrite_le(&jointIndices[1], 1, f);
+				fwrite_le(&jointIndices[2], 1, f);
+				fwrite_le(&jointIndices[3], 1, f);
 			}
 			break;
 		case 5:		// Weights
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 4 * sizeof( char ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 4 * sizeof( char ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				uc = (unsigned char)(_vertices[j].weights[0] * 255); fwrite( &uc, sizeof( char ), 1, f );
-				uc = (unsigned char)(_vertices[j].weights[1] * 255); fwrite( &uc, sizeof( char ), 1, f );
-				uc = (unsigned char)(_vertices[j].weights[2] * 255); fwrite( &uc, sizeof( char ), 1, f );
-				uc = (unsigned char)(_vertices[j].weights[3] * 255); fwrite( &uc, sizeof( char ), 1, f );
+				uc = (unsigned char)(_vertices[j].weights[0] * 255); fwrite_le(&uc, 1, f);
+				uc = (unsigned char)(_vertices[j].weights[1] * 255); fwrite_le(&uc, 1, f);
+				uc = (unsigned char)(_vertices[j].weights[2] * 255); fwrite_le(&uc, 1, f);
+				uc = (unsigned char)(_vertices[j].weights[3] * 255); fwrite_le(&uc, 1, f);
 			}
 			break;
 		case 6:		// Texture Coord Set 1
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 2 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 2 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				fwrite( &_vertices[j].texCoords[0].x, sizeof( float ), 1, f );
-				fwrite( &_vertices[j].texCoords[0].y, sizeof( float ), 1, f );
+				fwrite_le<float>(&_vertices[j].texCoords[0].x, 1, f);
+				fwrite_le<float>(&_vertices[j].texCoords[0].y, 1, f);
 			}
 			break;
 		case 7:		// Texture Coord Set 2
-			fwrite( &i, sizeof( int ), 1, f );
-			streamElemSize = 2 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+			fwrite_le(&i, 1, f);
+			streamElemSize = 2 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 			for( unsigned int j = 0; j < count; ++j )
 			{
-				fwrite( &_vertices[j].texCoords[1].x, sizeof( float ), 1, f );
-				fwrite( &_vertices[j].texCoords[1].y, sizeof( float ), 1, f );
+				fwrite_le<float>(&_vertices[j].texCoords[1].x, 1, f);
+				fwrite_le<float>(&_vertices[j].texCoords[1].y, 1, f);
 			}
 			break;
 		}
@@ -1012,76 +1031,76 @@ bool Converter::writeGeometry( const string &assetPath, const string &assetName 
 
 	// Write triangle indices
 	count = (unsigned int)_indices.size();
-	fwrite( &count, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
 
 	for( unsigned int i = 0; i < _indices.size(); ++i )
 	{
-		fwrite( &_indices[i], sizeof( int ), 1, f );
+		fwrite_le(&_indices[i], 1, f);
 	}
 
 	// Write morph targets
 	count = (unsigned int)_morphTargets.size();
-	fwrite( &count, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
 
 	for( unsigned int i = 0; i < _morphTargets.size(); ++i )
 	{
-		fwrite( &_morphTargets[i].name, 256, 1, f );
+        fwrite_le(_morphTargets[i].name, 256, f);
 		
 		// Write vertex indices
 		count = (unsigned int)_morphTargets[i].diffs.size();
-		fwrite( &count, sizeof( int ), 1, f );
+		fwrite_le(&count, 1, f);
 
 		for( unsigned int j = 0; j < count; ++j )
 		{
-			fwrite( &_morphTargets[i].diffs[j].vertIndex, sizeof( int ), 1, f );
+			fwrite_le(&_morphTargets[i].diffs[j].vertIndex, 1, f);
 		}
 		
 		// Write stream data
 		unsigned int numStreams = 4, streamElemSize;
-		fwrite( &numStreams, sizeof( int ), 1, f );
+		fwrite_le(&numStreams, 1, f);
 
 		for( unsigned int j = 0; j < 4; ++j )
 		{
 			switch( j )
 			{
 			case 0:		// Position
-				fwrite( &j, sizeof( int ), 1, f );
-				streamElemSize = 3 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+				fwrite_le(&j, 1, f);
+				streamElemSize = 3 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 				for( unsigned int k = 0; k < count; ++k )
 				{
-					fwrite( &_morphTargets[i].diffs[k].posDiff.x, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].posDiff.y, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].posDiff.z, sizeof( float ), 1, f );
+					fwrite_le<float>(&_morphTargets[i].diffs[k].posDiff.x, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].posDiff.y, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].posDiff.z, 1, f);
 				}
 				break;
 			case 1:		// Normal
-				fwrite( &j, sizeof( int ), 1, f );
-				streamElemSize = 3 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+				fwrite_le(&j, 1, f);
+				streamElemSize = 3 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 				for( unsigned int k = 0; k < count; ++k )
 				{
-					fwrite( &_morphTargets[i].diffs[k].normDiff.x, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].normDiff.y, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].normDiff.z, sizeof( float ), 1, f );
+					fwrite_le<float>(&_morphTargets[i].diffs[k].normDiff.x, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].normDiff.y, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].normDiff.z, 1, f);
 				}
 				break;
 			case 2:		// Tangent
-				fwrite( &j, sizeof( int ), 1, f );
-				streamElemSize = 3 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+				fwrite_le(&j, 1, f);
+				streamElemSize = 3 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 				for( unsigned int k = 0; k < count; ++k )
 				{
-					fwrite( &_morphTargets[i].diffs[k].tanDiff.x, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].tanDiff.y, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].tanDiff.z, sizeof( float ), 1, f );
+					fwrite_le<float>(&_morphTargets[i].diffs[k].tanDiff.x, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].tanDiff.y, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].tanDiff.z, 1, f);
 				}
 				break;
 			case 3:		// Bitangent
-				fwrite( &j, sizeof( int ), 1, f );
-				streamElemSize = 3 * sizeof( float ); fwrite( &streamElemSize, sizeof( int ), 1, f );
+				fwrite_le(&j, 1, f);
+				streamElemSize = 3 * sizeof( float ); fwrite_le(&streamElemSize, 1, f);
 				for( unsigned int k = 0; k < count; ++k )
 				{
-					fwrite( &_morphTargets[i].diffs[k].bitanDiff.x, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].bitanDiff.y, sizeof( float ), 1, f );
-					fwrite( &_morphTargets[i].diffs[k].bitanDiff.z, sizeof( float ), 1, f );
+					fwrite_le<float>(&_morphTargets[i].diffs[k].bitanDiff.x, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].bitanDiff.y, 1, f);
+					fwrite_le<float>(&_morphTargets[i].diffs[k].bitanDiff.z, 1, f);
 				}
 				break;
 			}
@@ -1336,7 +1355,7 @@ bool Converter::hasAnimation() const
 
 void Converter::writeAnimFrames( SceneNode &node, FILE *f ) const
 {
-	fwrite( &node.name, 256, 1, f );
+	fwrite_le(node.name, 256, f);
 		
 	// Animation compression: just store a single frame if all frames are equal
 	char canCompress = 0;
@@ -1354,7 +1373,7 @@ void Converter::writeAnimFrames( SceneNode &node, FILE *f ) const
 			}
 		}
 	}
-	fwrite( &canCompress, sizeof( char ), 1, f );
+	fwrite_le(&canCompress, 1, f);
 	
 	for( size_t i = 0; i < (canCompress ? 1 : node.frames.size()); ++i )
 	{
@@ -1362,16 +1381,16 @@ void Converter::writeAnimFrames( SceneNode &node, FILE *f ) const
 		node.frames[i].decompose( transVec, rotVec, scaleVec );
 		Quaternion rotQuat( rotVec.x, rotVec.y, rotVec.z );
 		
-		fwrite( &rotQuat.x, sizeof( float ), 1, f );
-		fwrite( &rotQuat.y, sizeof( float ), 1, f );
-		fwrite( &rotQuat.z, sizeof( float ), 1, f );
-		fwrite( &rotQuat.w, sizeof( float ), 1, f );
-		fwrite( &transVec.x, sizeof( float ), 1, f );
-		fwrite( &transVec.y, sizeof( float ), 1, f );
-		fwrite( &transVec.z, sizeof( float ), 1, f );
-		fwrite( &scaleVec.x, sizeof( float ), 1, f );
-		fwrite( &scaleVec.y, sizeof( float ), 1, f );
-		fwrite( &scaleVec.z, sizeof( float ), 1, f );
+		fwrite_le<float>(&rotQuat.x, 1, f);
+		fwrite_le<float>(&rotQuat.y, 1, f);
+		fwrite_le<float>(&rotQuat.z, 1, f);
+		fwrite_le<float>(&rotQuat.w, 1, f);
+		fwrite_le<float>(&transVec.x, 1, f);
+		fwrite_le<float>(&transVec.y, 1, f);
+		fwrite_le<float>(&transVec.z, 1, f);
+		fwrite_le<float>(&scaleVec.x, 1, f);
+		fwrite_le<float>(&scaleVec.y, 1, f);
+		fwrite_le<float>(&scaleVec.z, 1, f);
 	}
 }
 
@@ -1387,8 +1406,8 @@ bool Converter::writeAnimation( const string &assetPath, const string &assetName
 
 	// Write header
 	unsigned int version = 3;
-	fwrite( "H3DA", 4, 1, f );
-	fwrite( &version, sizeof( int ), 1, f );
+	fwrite_le("H3DA", 4, f);
+	fwrite_le(&version, 1, f);
 	
 	// Write number of nodes
 	unsigned int count = 0;
@@ -1396,8 +1415,8 @@ bool Converter::writeAnimation( const string &assetPath, const string &assetName
 		if( _joints[i]->frames.size() > 0 ) ++count;
 	for( unsigned int i = 0; i < _meshes.size(); ++i )
 		if( _meshes[i]->frames.size() > 0 ) ++count;
-	fwrite( &count, sizeof( int ), 1, f );
-	fwrite( &_frameCount, sizeof( int ), 1, f );
+	fwrite_le(&count, 1, f);
+	fwrite_le(&_frameCount, 1, f);
 
 	for( unsigned int i = 0; i < _joints.size(); ++i )
 	{

--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -10,6 +10,7 @@
 //
 // *************************************************************************************************
 
+#include <utEndian.h>
 #include "egAnimation.h"
 #include "egModules.h"
 #include "egCom.h"
@@ -93,19 +94,19 @@ bool AnimationResource::load( const char *data, int size )
 	
 	// Check header and version
 	char id[4];
-	memcpy( &id, pData, 4 ); pData += 4;
+	pData = elemcpy_le(id, (char*)(pData), 4);
 	if( id[0] != 'H' || id[1] != '3' || id[2] != 'D' || id[3] != 'A' )
 		return raiseError( "Invalid animation resource" );
 	
 	uint32 version;
-	memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&version, (uint32*)(pData), 1);
 	if( version != 2 && version != 3 )
 		return raiseError( "Unsupported version of animation resource" );
 	
 	// Load animation data
 	uint32 numEntities;
-	memcpy( &numEntities, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-	memcpy( &_numFrames, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&numEntities, (uint32*)(pData), 1);
+	pData = elemcpy_le(&_numFrames, (uint32*)(pData), 1);
 
 	_entities.resize( numEntities );
 
@@ -114,13 +115,13 @@ bool AnimationResource::load( const char *data, int size )
 		char name[256], compressed = 0;
 		AnimResEntity &entity = _entities[i];
 		
-		memcpy( name, pData, 256 ); pData += 256;
+		pData = elemcpy_le(name, (char*)(pData), 256);
 		entity.nameId = AnimationController::hashName( name );
 		
 		// Animation compression
 		if( version == 3 )
 		{
-			memcpy( &compressed, pData, sizeof( char ) ); pData += sizeof( char ); 
+			pData = elemcpy_le(&compressed, (char*)(pData), 1); 
 		}
 
 		entity.frames.resize( compressed ? 1 : _numFrames );
@@ -128,18 +129,18 @@ bool AnimationResource::load( const char *data, int size )
 		{
 			Frame &frame = entity.frames[j];
 
-			memcpy( &frame.rotQuat.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.z, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.rotQuat.w, pData, sizeof( float ) ); pData += sizeof( float );
+			pData = elemcpy_le(&frame.rotQuat.x, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.rotQuat.y, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.rotQuat.z, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.rotQuat.w, (float*)(pData), 1);
 
-			memcpy( &frame.transVec.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.transVec.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.transVec.z, pData, sizeof( float ) ); pData += sizeof( float );
+			pData = elemcpy_le(&frame.transVec.x, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.transVec.y, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.transVec.z, (float*)(pData), 1);
 
-			memcpy( &frame.scaleVec.x, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.scaleVec.y, pData, sizeof( float ) ); pData += sizeof( float );
-			memcpy( &frame.scaleVec.z, pData, sizeof( float ) ); pData += sizeof( float );
+			pData = elemcpy_le(&frame.scaleVec.x, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.scaleVec.y, (float*)(pData), 1);
+			pData = elemcpy_le(&frame.scaleVec.z, (float*)(pData), 1);
 
 			// Prebake transformation matrix for fast animation path
 			frame.bakedTransMat.scale( frame.scaleVec.x, frame.scaleVec.y, frame.scaleVec.z );

--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -10,7 +10,7 @@
 //
 // *************************************************************************************************
 
-#include <utEndian.h>
+#include "utEndian.h"
 #include "egAnimation.h"
 #include "egModules.h"
 #include "egCom.h"

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -10,7 +10,7 @@
 //
 // *************************************************************************************************
 
-#include <utEndian.h>
+#include "utEndian.h"
 #include "egGeometry.h"
 #include "egResource.h"
 #include "egAnimation.h"

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -10,6 +10,7 @@
 //
 // *************************************************************************************************
 
+#include <utEndian.h>
 #include "egGeometry.h"
 #include "egResource.h"
 #include "egAnimation.h"
@@ -158,17 +159,17 @@ bool GeometryResource::load( const char *data, int size )
 	
 	// Check header and version
 	char id[4];
-	memcpy( &id, pData, 4 ); pData += 4;
+	pData = elemcpy_le(id, (char*)(pData), 4);
 	if( id[0] != 'H' || id[1] != '3' || id[2] != 'D' || id[3] != 'G' )
 		return raiseError( "Invalid geometry resource" );
 
 	uint32 version;
-	memcpy( &version, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&version, (uint32*)(pData), 1);
 	if( version != 5 ) return raiseError( "Unsupported version of geometry file" );
 
 	// Load joints
 	uint32 count;
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&count, (uint32*)(pData), 1);
 
 	if( count > 75 )
 		Modules::log().writeWarning( "Geometry resource '%s': Model has more than 75 joints; this may cause defective behavior", _name.c_str() );
@@ -181,14 +182,14 @@ bool GeometryResource::load( const char *data, int size )
 		// Inverse bind matrix
 		for( uint32 j = 0; j < 16; ++j )
 		{
-			memcpy( &joint.invBindMat.x[j], pData, sizeof( float ) ); pData += sizeof( float );
+			pData = elemcpy_le(&joint.invBindMat.x[j], (float*)(pData), 1);
 		}
 	}
 	
 	// Load vertex stream data
 	uint32 streamSize;
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );			// Number of streams
-	memcpy( &streamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );	// Number of vertices
+	pData = elemcpy_le(&count, (uint32*)(pData), 1);		// Number of streams
+	pData = elemcpy_le(&streamSize, (uint32*)(pData), 1);	// Number of vertices
 
 	_vertCount = streamSize;
 	_vertPosData = new Vec3f[_vertCount];
@@ -207,8 +208,8 @@ bool GeometryResource::load( const char *data, int size )
 		unsigned char uc;
 		short sh;
 		uint32 streamID, streamElemSize;
-		memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-		memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		pData = elemcpy_le(&streamID, (uint32*)(pData), 1);
+		pData = elemcpy_le(&streamElemSize, (uint32*)(pData), 1);
 		std::string errormsg;
 
 		switch( streamID )
@@ -221,9 +222,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertPosData[j].x, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertPosData[j].y, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertPosData[j].z, pData, sizeof( float ) ); pData += sizeof( float );
+				pData = elemcpy_le(&_vertPosData[j].x, (float*)(pData), 1);
+				pData = elemcpy_le(&_vertPosData[j].y, (float*)(pData), 1);
+				pData = elemcpy_le(&_vertPosData[j].z, (float*)(pData), 1);
 			}
 			break;
 		case 1:		// Normal
@@ -234,9 +235,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].normal.z = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].normal.x = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].normal.y = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].normal.z = sh / 32767.0f;
 			}
 			break;
 		case 2:		// Tangent
@@ -247,9 +248,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); _vertTanData[j].tangent.z = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].tangent.x = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].tangent.y = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); _vertTanData[j].tangent.z = sh / 32767.0f;
 			}
 			break;
 		case 3:		// Bitangent
@@ -260,9 +261,9 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].x = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].y = sh / 32767.0f;
-				memcpy( &sh, pData, sizeof( short ) ); pData += sizeof( short ); bitangents[j].z = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); bitangents[j].x = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); bitangents[j].y = sh / 32767.0f;
+				pData = elemcpy_le(&sh, (short*)(pData), 1); bitangents[j].z = sh / 32767.0f;
 			}
 			break;
 		case 4:		// Joint indices
@@ -273,10 +274,10 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].jointVec[0] = (float)uc;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].jointVec[1] = (float)uc;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].jointVec[2] = (float)uc;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].jointVec[3] = (float)uc;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].jointVec[0] = (float)uc;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].jointVec[1] = (float)uc;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].jointVec[2] = (float)uc;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].jointVec[3] = (float)uc;
 			}
 			break;
 		case 5:		// Weights
@@ -287,10 +288,10 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].weightVec[0] = uc / 255.0f;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].weightVec[1] = uc / 255.0f;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].weightVec[2] = uc / 255.0f;
-				memcpy( &uc, pData, sizeof( char ) ); pData += sizeof( char ); _vertStaticData[j].weightVec[3] = uc / 255.0f;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].weightVec[0] = uc / 255.0f;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].weightVec[1] = uc / 255.0f;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].weightVec[2] = uc / 255.0f;
+				pData = elemcpy_le(&uc, (unsigned char*)(pData), 1); _vertStaticData[j].weightVec[3] = uc / 255.0f;
 			}
 			break;
 		case 6:		// Texture Coord Set 1
@@ -301,8 +302,8 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertStaticData[j].u0, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertStaticData[j].v0, pData, sizeof( float ) ); pData += sizeof( float );
+				pData = elemcpy_le(&_vertStaticData[j].u0, (float*)(pData), 1);
+				pData = elemcpy_le(&_vertStaticData[j].v0, (float*)(pData), 1);
 			}
 			break;
 		case 7:		// Texture Coord Set 2
@@ -313,8 +314,8 @@ bool GeometryResource::load( const char *data, int size )
 			}
 			for( uint32 j = 0; j < streamSize; ++j )
 			{
-				memcpy( &_vertStaticData[j].u1, pData, sizeof( float ) ); pData += sizeof( float );
-				memcpy( &_vertStaticData[j].v1, pData, sizeof( float ) ); pData += sizeof( float );
+				pData = elemcpy_le(&_vertStaticData[j].u1, (float*)(pData), 1);
+				pData = elemcpy_le(&_vertStaticData[j].v1, (float*)(pData), 1);
 			}
 			break;
 		default:
@@ -337,7 +338,7 @@ bool GeometryResource::load( const char *data, int size )
 	delete[] bitangents;
 		
 	// Load triangle indices
-	memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&count, (uint32*)(pData), 1);
 
 	_indexCount = count;
     _16BitIndices = _vertCount <= 65536;
@@ -348,7 +349,7 @@ bool GeometryResource::load( const char *data, int size )
 		uint16 *pIndexData = (uint16 *)_indexData;
 		for( uint32 i = 0; i < count; ++i )
 		{
-			memcpy( &index, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			pData = elemcpy_le(&index, (uint32*)(pData), 1);
 			pIndexData[i] = (uint16)index;
 		}
 	}
@@ -357,13 +358,13 @@ bool GeometryResource::load( const char *data, int size )
 		uint32 *pIndexData = (uint32 *)_indexData;
 		for( uint32 i = 0; i < count; ++i )
 		{
-			memcpy( &pIndexData[i], pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			pData = elemcpy_le(&pIndexData[i], (uint32*)(pData), 1);
 		}
 	}
 
 	// Load morph targets
 	uint32 numTargets;
-	memcpy( &numTargets, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+	pData = elemcpy_le(&numTargets, (uint32*)(pData), 1);
 
 	_morphTargets.resize( numTargets );
 	for( uint32 i = 0; i < numTargets; ++i )
@@ -376,20 +377,20 @@ bool GeometryResource::load( const char *data, int size )
 		
 		// Read vertex indices
 		uint32 morphStreamSize;
-		memcpy( &morphStreamSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		pData = elemcpy_le(&morphStreamSize, (uint32*)(pData), 1);
 		mt.diffs.resize( morphStreamSize );
 		for( uint32 j = 0; j < morphStreamSize; ++j )
 		{
-			memcpy( &mt.diffs[j].vertIndex, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			pData = elemcpy_le(&mt.diffs[j].vertIndex, (uint32*)(pData), 1);
 		}
 		
 		// Loop over streams
-		memcpy( &count, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+		pData = elemcpy_le(&count, (uint32*)(pData), 1);
 		for( uint32 j = 0; j < count; ++j )
 		{
 			uint32 streamID, streamElemSize;
-			memcpy( &streamID, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
-			memcpy( &streamElemSize, pData, sizeof( uint32 ) ); pData += sizeof( uint32 );
+			pData = elemcpy_le(&streamID, (uint32*)(pData), 1);
+			pData = elemcpy_le(&streamElemSize, (uint32*)(pData), 1);
 
 			switch( streamID )
 			{
@@ -397,27 +398,27 @@ bool GeometryResource::load( const char *data, int size )
 				if( streamElemSize != 12 ) return raiseError( "Invalid position morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].posDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].posDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].posDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					pData = elemcpy_le(&mt.diffs[k].posDiff.x, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].posDiff.y, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].posDiff.z, (float*)(pData), 1);
 				}
 				break;
 			case 1:		// Normal
 				if( streamElemSize != 12 ) return raiseError( "Invalid normal morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].normDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].normDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].normDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					pData = elemcpy_le(&mt.diffs[k].normDiff.x, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].normDiff.y, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].normDiff.z, (float*)(pData), 1);
 				}
 				break;
 			case 2:		// Tangent
 				if( streamElemSize != 12 ) return raiseError( "Invalid tangent morph stream" );
 				for( uint32 k = 0; k < morphStreamSize; ++k )
 				{
-					memcpy( &mt.diffs[k].tanDiff.x, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].tanDiff.y, pData, sizeof( float ) ); pData += sizeof( float );
-					memcpy( &mt.diffs[k].tanDiff.z, pData, sizeof( float ) ); pData += sizeof( float );
+					pData = elemcpy_le(&mt.diffs[k].tanDiff.x, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].tanDiff.y, (float*)(pData), 1);
+					pData = elemcpy_le(&mt.diffs[k].tanDiff.z, (float*)(pData), 1);
 				}
 				break;
 			case 3:		// Bitangent
@@ -482,7 +483,6 @@ bool GeometryResource::load( const char *data, int size )
 	
 	return true;
 }
-
 
 int GeometryResource::getElemCount( int elem ) const
 {

--- a/Horde3D/Source/Horde3DEngine/egMain.cpp
+++ b/Horde3D/Source/Horde3DEngine/egMain.cpp
@@ -35,13 +35,26 @@
 
 
 // Check some platform-dependent assumptions
-// Note: this function is never called but just wraps the compile time asserts
 static void __ValidatePlatform__()
 {
 	ASSERT_STATIC( sizeof( int64 ) == 8 );
 	ASSERT_STATIC( sizeof( int ) == 4 );
 	ASSERT_STATIC( sizeof( short ) == 2 );
 	ASSERT_STATIC( sizeof( char ) == 1 );
+    
+    // Check if platform endianess detection is correct.
+    union {
+        uint32         u32;
+        unsigned char  bytes[4];
+    } e;
+    e.u32 = 0xAABBCCDD;
+#ifdef PLATFORM_LITTLE_ENDIAN
+    ASSERT(e.bytes[0] == 0xDD && e.bytes[1] == 0xCC && e.bytes[2] == 0xBB && e.bytes[3] == 0xAA);
+#elif PLATFORM_BIG_ENDIAN
+    ASSERT(e.bytes[3] == 0xDD && e.bytes[2] == 0xCC && e.bytes[1] == 0xBB && e.bytes[0] == 0xAA);
+#else
+#   error Unknown endianess
+#endif
 }
 
 
@@ -94,6 +107,7 @@ DLLEXP bool h3dInit()
 	}
 	initialized = true;
 
+    __ValidatePlatform__();
 	return Modules::init();
 }
 

--- a/Horde3D/Source/Horde3DEngine/egTexture.cpp
+++ b/Horde3D/Source/Horde3DEngine/egTexture.cpp
@@ -10,6 +10,7 @@
 //
 // *************************************************************************************************
 
+#include "utEndian.h"
 #include "egTexture.h"
 #include "egModules.h"
 #include "egCom.h"
@@ -219,7 +220,7 @@ bool TextureResource::raiseError( const string &msg )
 
 bool TextureResource::checkDDS( const char *data, int size ) const
 {
-	return size > 128 && *((uint32 *)data) == FOURCC( 'D', 'D', 'S', ' ' );
+    return size > 128 && *((uint32 *)data) == FOURCC( 'D', 'D', 'S', ' ' );
 }
 
 
@@ -227,8 +228,9 @@ bool TextureResource::loadDDS( const char *data, int size )
 {
 	ASSERT_STATIC( sizeof( DDSHeader ) == 128 );
 
-	memcpy( &ddsHeader, data, 128 );
-	
+    // all of the dds header is uint32 data, so we consider it a array of uint32s.
+	elemcpy_le((uint32*)(&ddsHeader), (uint32*)(data), 128 / sizeof(uint32));
+
 	// Check header
 	// There are some flags that are required to be set for every dds but we don't check them
 	if( ddsHeader.dwSize != 124 )

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -594,29 +594,29 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 	// Write Horde flag
     pData = elemcpyd_le((char*)(pData), "H3DG", 4);
 	// Set version to 5 
-	pData = elemset_le<uint32>((uint32*)(pData), 5);
+	pData = elemset_le((uint32*)(pData), 5u);
 	// Set joint count (zero for this method)
-	pData = elemset_le<uint32>((uint32*)(pData), 0);
+	pData = elemset_le((uint32*)(pData), 0u);
 	// Set number of streams
-	pData = elemset_le<uint32>((uint32*)(pData), 1 + numTexSets + ( normalData ? 1 : 0 ) + ((tangentData && bitangentData) ? 2 : 0));
+	pData = elemset_le((uint32*)(pData), 1u + numTexSets + ( normalData ? 1 : 0 ) + ((tangentData && bitangentData) ? 2 : 0));
 	// Write number of elements in each stream
-	pData = elemset_le<uint32>((uint32*)(pData), numVertices);
+	pData = elemset_le((int32*)(pData), numVertices);
 
 	// Beginning of stream data
 
 	// Vertex Stream ID
-	pData = elemset_le<uint32>((uint32*)(pData), 0);
+	pData = elemset_le((uint32*)(pData), 0u);
 	// set vertex stream element size
-	pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 3);
+	pData = elemset_le((uint32*)(pData), sizeof( float ) * 3);
 	// vertex data
     pData = elemcpyd_le((float*)(pData), posData, numVertices * 3);
 
 	if( normalData )
 	{
 		// Normals Stream ID
-		pData = elemset_le<uint32>((uint32*)(pData), 1);
+		pData = elemset_le((uint32*)(pData), 1u);
 		// set normal stream element size
-		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
 		// normal data
         pData = elemcpyd_le((short*)(pData), normalData, numVertices * 3);
 	}
@@ -624,16 +624,16 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 	if( tangentData && bitangentData )
 	{
 		// Tangent Stream ID
-		pData = elemset_le<uint32>((uint32*)(pData), 2);
+		pData = elemset_le((uint32*)(pData), 2u);
 		// set tangent stream element size
-		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
 		// tangent data
 		pData = elemcpyd_le((short*)(pData), tangentData, numVertices * 3);
 	
 		// Bitangent Stream ID
-		pData = elemset_le<uint32>((uint32*)(pData), 3);
+		pData = elemset_le((uint32*)(pData), 3u);
 		// set bitangent stream element size
-		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
 		// bitangent data
 		pData = elemcpyd_le((short*)(pData), bitangentData, numVertices * 3);
 	}
@@ -641,25 +641,25 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 	// texture coordinates stream
 	if( texData1 )
 	{
-		pData = elemset_le<uint32>((uint32*)(pData), 6); // Tex Set 1
-		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemset_le((uint32*)(pData), 6u); // Tex Set 1
+		pData = elemset_le((uint32*)(pData), sizeof( float ) * 2); // stream element size
 		pData = elemcpyd_le((float *)(pData), texData1, 2 * numVertices ); // stream data
 	}
 	if( texData2 )
 	{
-		pData = elemset_le<uint32>((uint32*)(pData), 7); // Tex Set 2
-		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemset_le((uint32*)(pData), 7u); // Tex Set 2
+		pData = elemset_le((uint32*)(pData), sizeof( float ) * 2); // stream element size
 		pData = elemcpyd_le((float *)(pData), texData2, 2 * numVertices ); // stream data
 	}
 
 	// Set number of indices
-	pData = elemset_le<uint32>((uint32*)(pData), numTriangleIndices);	
+	pData = elemset_le((int32*)(pData), numTriangleIndices);	
 	
 	// index data
-	pData = elemcpyd_le(pData, indexData, numTriangleIndices);			
+	pData = elemcpyd_le((uint32*)(pData), indexData, numTriangleIndices);			
 
 	// Set number of morph targets to zero
-	pData = elemset_le<uint32>((uint32*)(pData), 0);
+	pData = elemset_le((uint32*)(pData), 0u);
 
 	if ( res ) h3dLoadResource( res, data, size );
 	delete[] data;

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -607,7 +607,7 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 	// Vertex Stream ID
 	pData = elemset_le((uint32*)(pData), 0u);
 	// set vertex stream element size
-	pData = elemset_le((uint32*)(pData), sizeof( float ) * 3);
+	pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 3);
 	// vertex data
     pData = elemcpyd_le((float*)(pData), posData, numVertices * 3);
 
@@ -616,7 +616,7 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 		// Normals Stream ID
 		pData = elemset_le((uint32*)(pData), 1u);
 		// set normal stream element size
-		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// normal data
         pData = elemcpyd_le((short*)(pData), normalData, numVertices * 3);
 	}
@@ -626,14 +626,14 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 		// Tangent Stream ID
 		pData = elemset_le((uint32*)(pData), 2u);
 		// set tangent stream element size
-		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// tangent data
 		pData = elemcpyd_le((short*)(pData), tangentData, numVertices * 3);
 	
 		// Bitangent Stream ID
 		pData = elemset_le((uint32*)(pData), 3u);
 		// set bitangent stream element size
-		pData = elemset_le((uint32*)(pData), sizeof( short ) * 3);
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// bitangent data
 		pData = elemcpyd_le((short*)(pData), bitangentData, numVertices * 3);
 	}
@@ -642,13 +642,13 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 	if( texData1 )
 	{
 		pData = elemset_le((uint32*)(pData), 6u); // Tex Set 1
-		pData = elemset_le((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
 		pData = elemcpyd_le((float *)(pData), texData1, 2 * numVertices ); // stream data
 	}
 	if( texData2 )
 	{
 		pData = elemset_le((uint32*)(pData), 7u); // Tex Set 2
-		pData = elemset_le((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
 		pData = elemcpyd_le((float *)(pData), texData2, 2 * numVertices ); // stream data
 	}
 

--- a/Horde3D/Source/Horde3DUtils/main.cpp
+++ b/Horde3D/Source/Horde3DUtils/main.cpp
@@ -13,6 +13,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #include "Horde3D.h"
 #include "utPlatform.h"
+#include "utEndian.h"
 #include "utMath.h"
 #include <math.h>
 #ifdef PLATFORM_WIN
@@ -591,81 +592,74 @@ DLLEXP H3DRes h3dutCreateGeometryRes(
 
 	char *pData = data;
 	// Write Horde flag
-	pData[0] = 'H'; pData[1] = '3'; pData[2] = 'D'; pData[3] = 'G'; pData += 4;
+    pData = elemcpyd_le((char*)(pData), "H3DG", 4);
 	// Set version to 5 
-	*( (uint32 *)pData ) = 5; pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), 5);
 	// Set joint count (zero for this method)
-	*( (uint32 *)pData ) = 0; pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), 0);
 	// Set number of streams
-	*( (uint32 *)pData ) = 1 + numTexSets + ( normalData ? 1 : 0 ) + ((tangentData && bitangentData) ? 2 : 0); pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), 1 + numTexSets + ( normalData ? 1 : 0 ) + ((tangentData && bitangentData) ? 2 : 0));
 	// Write number of elements in each stream
-	*( (uint32 *)pData ) = numVertices; pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), numVertices);
 
 	// Beginning of stream data
 
 	// Vertex Stream ID
-	*( (uint32 *)pData ) = 0; pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), 0);
 	// set vertex stream element size
-	*( (uint32 *)pData ) = sizeof( float ) * 3; pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 3);
 	// vertex data
-	memcpy( (float*) pData, posData, numVertices * sizeof( float ) * 3 );
-	pData += numVertices * sizeof( float ) * 3;
+    pData = elemcpyd_le((float*)(pData), posData, numVertices * 3);
 
 	if( normalData )
 	{
 		// Normals Stream ID
-		*( (uint32 *)pData ) = 1; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), 1);
 		// set normal stream element size
-		*( (uint32 *)pData ) = sizeof( short ) * 3; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// normal data
-		memcpy( (short*) pData, normalData, numVertices * sizeof( short ) * 3 );
-		pData += numVertices * sizeof( short ) * 3;
+        pData = elemcpyd_le((short*)(pData), normalData, numVertices * 3);
 	}
 
 	if( tangentData && bitangentData )
 	{
 		// Tangent Stream ID
-		*( (uint32 *)pData ) = 2; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), 2);
 		// set tangent stream element size
-		*( (uint32 *)pData ) = sizeof( short ) * 3; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// tangent data
-		memcpy( (short*) pData, tangentData, numVertices * sizeof( short ) * 3 );
-		pData += numVertices * sizeof( short ) * 3;
+		pData = elemcpyd_le((short*)(pData), tangentData, numVertices * 3);
 	
 		// Bitangent Stream ID
-		*( (uint32 *)pData ) = 3; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), 3);
 		// set bitangent stream element size
-		*( (uint32 *)pData ) = sizeof( short ) * 3; pData += sizeof( uint32 );
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( short ) * 3);
 		// bitangent data
-		memcpy( (short*) pData, bitangentData, numVertices * sizeof( short ) * 3 );
-		pData += numVertices * sizeof( short ) * 3;
+		pData = elemcpyd_le((short*)(pData), bitangentData, numVertices * 3);
 	}
 
 	// texture coordinates stream
 	if( texData1 )
 	{
-		*( (uint32 *)pData ) = 6; pData += sizeof( uint32 ); // Tex Set 1
-		*( (uint32 *)pData ) = sizeof( float ) * 2; pData += sizeof( uint32 ); // stream element size
-		memcpy( (float *)pData, texData1, sizeof( float ) * 2 * numVertices ); // stream data
-		pData += sizeof( float ) * 2 * numVertices; 
+		pData = elemset_le<uint32>((uint32*)(pData), 6); // Tex Set 1
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemcpyd_le((float *)(pData), texData1, 2 * numVertices ); // stream data
 	}
 	if( texData2 )
 	{
-		*( (uint32 *)pData ) = 7; pData += sizeof( uint32 ); // Tex Set 2
-		*( (uint32 *)pData ) = sizeof( float ) * 2; pData += sizeof( uint32 ); // stream element size
-		memcpy( (float *)pData, texData2, sizeof( float ) * 2 * numVertices ); // stream data
-		pData += sizeof( float ) * 2 * numVertices; 
+		pData = elemset_le<uint32>((uint32*)(pData), 7); // Tex Set 2
+		pData = elemset_le<uint32>((uint32*)(pData), sizeof( float ) * 2); // stream element size
+		pData = elemcpyd_le((float *)(pData), texData2, 2 * numVertices ); // stream data
 	}
 
 	// Set number of indices
-	*( (uint32 *) pData ) = numTriangleIndices; pData += sizeof( uint32 );	
+	pData = elemset_le<uint32>((uint32*)(pData), numTriangleIndices);	
 	
 	// index data
-	memcpy( pData, indexData, numTriangleIndices * sizeof( uint32 ) );
-	pData += numTriangleIndices * sizeof( uint32 );				
+	pData = elemcpyd_le(pData, indexData, numTriangleIndices);			
 
 	// Set number of morph targets to zero
-	*( (uint32 *) pData ) = 0;	pData += sizeof( uint32 );
+	pData = elemset_le<uint32>((uint32*)(pData), 0);
 
 	if ( res ) h3dLoadResource( res, data, size );
 	delete[] data;
@@ -689,21 +683,21 @@ DLLEXP bool h3dutCreateTGAImage( const unsigned char *pixels, int width, int hei
 	// Build TGA header
 	char c;
 	short s;
-	c = 0;      memcpy( data, &c, 1 ); data += 1;  // idLength
-	c = 0;      memcpy( data, &c, 1 ); data += 1;  // colmapType
-	c = 2;      memcpy( data, &c, 1 ); data += 1;  // imageType
-	s = 0;      memcpy( data, &s, 2 ); data += 2;  // colmapStart
-	s = 0;      memcpy( data, &s, 2 ); data += 2;  // colmapLength
-	c = 0;      memcpy( data, &c, 1 ); data += 1;  // colmapBits
-	s = 0;      memcpy( data, &s, 2 ); data += 2;  // x
-	s = 0;      memcpy( data, &s, 2 ); data += 2;  // y
-	s = width;  memcpy( data, &s, 2 ); data += 2;  // width
-	s = height; memcpy( data, &s, 2 ); data += 2;  // height
-	c = bpp;    memcpy( data, &c, 1 ); data += 1;  // bpp
-	c = 0;      memcpy( data, &c, 1 ); data += 1;  // imageDesc
+	c = 0;      data = elemcpyd_le( data, &c, 1 );              // idLength
+	c = 0;      data = elemcpyd_le( data, &c, 1 );              // colmapType
+	c = 2;      data = elemcpyd_le( data, &c, 1 );              // imageType
+	s = 0;      data = elemcpyd_le( (short*) data, &s, 1 );     // colmapStart
+	s = 0;      data = elemcpyd_le( (short*) data, &s, 1 );     // colmapLength
+	c = 0;      data = elemcpyd_le( data, &c, 1 );              // colmapBits
+	s = 0;      data = elemcpyd_le( (short*) data, &s, 1 );     // x
+	s = 0;      data = elemcpyd_le( (short*) data, &s, 1 );     // y
+	s = width;  data = elemcpyd_le( (short*) data, &s, 1 );     // width
+	s = height; data = elemcpyd_le( (short*) data, &s, 1 );     // height
+	c = bpp;    data = elemcpyd_le( data, &c, 1 );              // bpp
+	c = 0;      data = elemcpyd_le( data, &c, 1 );              // imageDesc
 
 	// Copy data
-	if( pixels ) memcpy( data, pixels, width * height * (bpp / 8) );
+    if( pixels ) memcpy( data, pixels, width * height * (bpp / 8) );
 
 	return true;
 }

--- a/Horde3D/Source/Shared/utEndian.h
+++ b/Horde3D/Source/Shared/utEndian.h
@@ -78,14 +78,13 @@ inline void swap_endian(const float* first, const float* last, float* d_first)
 
 #include <algorithm>
 
-template< class InputIt, class OutputIt>
-inline char* elemcpy_le(OutputIt dest, InputIt src, size_t num_elems)
+template<class T>
+inline char* elemcpy_le(T* dest, const T* src, size_t num_elems)
 {
 #if defined(PLATFORM_BIG_ENDIAN)
     swap_endian(src, src + num_elems, dest);
 #elif defined(PLATFORM_LITTLE_ENDIAN)
-    //memcpy(dest, src, num_elems * sizeof(*first));
-    std::copy(src, src + num_elems, dest);
+    memcpy(dest, src, num_elems * sizeof(*src));
 #else
     #error Unknown endianess
 #endif
@@ -93,8 +92,8 @@ inline char* elemcpy_le(OutputIt dest, InputIt src, size_t num_elems)
 }
 
 // Same as elemcpy_le except it returns the new 'dest' pointer instead of a new 'src'.
-template< class InputIt, class OutputIt>
-inline char* elemcpyd_le(OutputIt dest, InputIt src, size_t num_elems)
+template<class T>
+inline char* elemcpyd_le(T* dest, const T* src, size_t num_elems)
 {
     elemcpy_le(dest, src, num_elems);
     return (char*)(dest) + num_elems * sizeof(*dest);

--- a/Horde3D/Source/Shared/utEndian.h
+++ b/Horde3D/Source/Shared/utEndian.h
@@ -100,7 +100,7 @@ inline char* elemcpyd_le(T* dest, const T* src, size_t num_elems)
 template<class T>
 inline char* elemset_le(T* dest, T value)
 {
-    return elemcpy_le(dest, &value, 1);
+    return elemcpyd_le(dest, &value, 1);
 }
 
 template<class T>

--- a/Horde3D/Source/Shared/utEndian.h
+++ b/Horde3D/Source/Shared/utEndian.h
@@ -76,8 +76,6 @@ inline void swap_endian(const float* first, const float* last, float* d_first)
                 reinterpret_cast<uint32*>(d_first));
 }
 
-#include <algorithm>
-
 template<class T>
 inline char* elemcpy_le(T* dest, const T* src, size_t num_elems)
 {

--- a/Horde3D/Source/Shared/utEndian.h
+++ b/Horde3D/Source/Shared/utEndian.h
@@ -78,19 +78,40 @@ inline void swap_endian(const float* first, const float* last, float* d_first)
 
 #include <algorithm>
 
-template<class OutputIt, class InputIt>
+template< class InputIt, class OutputIt>
 inline char* elemcpy_le(OutputIt dest, InputIt src, size_t num_elems)
 {
 #if defined(PLATFORM_BIG_ENDIAN)
     swap_endian(src, src + num_elems, dest);
-    return (char*)(src) + num_elems * sizeof(*src);
 #elif defined(PLATFORM_LITTLE_ENDIAN)
     //memcpy(dest, src, num_elems * sizeof(*first));
     std::copy(src, src + num_elems, dest);
-    return (char*)(src) + num_elems * sizeof(*src);
 #else
     #error Unknown endianess
 #endif
+    return (char*)(src) + num_elems * sizeof(*src);
+}
+
+// Same as elemcpy_le except it returns the new 'dest' pointer instead of a new 'src'.
+template< class InputIt, class OutputIt>
+inline char* elemcpyd_le(OutputIt dest, InputIt src, size_t num_elems)
+{
+    elemcpy_le(dest, src, num_elems);
+    return (char*)(dest) + num_elems * sizeof(*dest);
+}
+
+template<class T>
+inline char* elemset_le(T* dest, T value)
+{
+    return elemcpy_le(dest, &value, 1);
+}
+
+template<class T>
+inline T elemget_le(T* src)
+{
+    T value;
+    elemcpy_le(&value, src, 1);
+    return value;
 }
 
 #endif

--- a/Horde3D/Source/Shared/utEndian.h
+++ b/Horde3D/Source/Shared/utEndian.h
@@ -1,0 +1,96 @@
+// *************************************************************************************************
+//
+// Horde3D
+//   Next-Generation Graphics Engine
+// --------------------------------------
+// Copyright (C) 2006-2011 Nicolas Schulz
+//
+// This software is distributed under the terms of the Eclipse Public License v1.0.
+// A copy of the license may be obtained at: http://www.eclipse.org/legal/epl-v10.html
+//
+#ifndef _utEndian_H_
+#define _utEndian_H_
+
+#include <utPlatform.h>
+#include <cstring>
+
+//for testing
+//#undef PLATFORM_LITTLE_ENDINA
+//#define PLATFORM_BIG_ENDIAN
+
+inline void swap_endian(const char* first, const char* last, char* d_first)
+{
+    memcpy(d_first, first, (last - first));
+}
+
+inline void swap_endian(const unsigned char* first, const unsigned char* last, unsigned char* d_first)
+{
+    memcpy(d_first, first, (last - first));
+}
+
+inline void swap_endian(const uint16* first, const uint16* last, uint16* d_first)
+{
+    for(; first != last; ++first, ++d_first)
+    {
+        uint16 val = *first;
+        *d_first = ((val >> 8) & 0x00FF) |
+                   ((val << 8) & 0xFF00);
+    }
+}
+
+inline void swap_endian(const int16* first, const int16* last, int16* d_first)
+{
+    // signed shifting performs arithmetic shift which extends the sign bit, we don't really want this.
+    // so let's call the unsigned version.
+    swap_endian(reinterpret_cast<const uint16*>(first),
+                reinterpret_cast<const uint16*>(last),
+                reinterpret_cast<uint16*>(d_first));
+}
+
+inline void swap_endian(const uint32* first, const uint32* last, uint32* d_first)
+{
+    for(; first != last; ++first, ++d_first)
+    {
+        uint32 val = *first;
+        *d_first = ((val >> 24) & 0x000000FF) |
+                   ((val << 8)  & 0x00FF0000) |
+                   ((val >> 8)  & 0x0000FF00) |
+                   ((val << 24) & 0xFF000000);
+    }
+}
+
+inline void swap_endian(const int32* first, const int32* last, int32* d_first)
+{
+    // signed shifting performs arithmetic shift which extends the sign bit, we don't really want this.
+    // so let's call the unsigned version.
+    swap_endian(reinterpret_cast<const uint32*>(first),
+                reinterpret_cast<const uint32*>(last),
+                reinterpret_cast<uint32*>(d_first));
+}
+
+inline void swap_endian(const float* first, const float* last, float* d_first)
+{
+    ASSERT_STATIC(sizeof(float) == sizeof(uint32));
+    swap_endian(reinterpret_cast<const uint32*>(first),
+                reinterpret_cast<const uint32*>(last),
+                reinterpret_cast<uint32*>(d_first));
+}
+
+#include <algorithm>
+
+template<class OutputIt, class InputIt>
+inline char* elemcpy_le(OutputIt dest, InputIt src, size_t num_elems)
+{
+#if defined(PLATFORM_BIG_ENDIAN)
+    swap_endian(src, src + num_elems, dest);
+    return (char*)(src) + num_elems * sizeof(*src);
+#elif defined(PLATFORM_LITTLE_ENDIAN)
+    //memcpy(dest, src, num_elems * sizeof(*first));
+    std::copy(src, src + num_elems, dest);
+    return (char*)(src) + num_elems * sizeof(*src);
+#else
+    #error Unknown endianess
+#endif
+}
+
+#endif

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -36,6 +36,42 @@
 #	endif
 #endif
 
+// Endianess
+#if defined (__GLIBC__)
+#   include <endian.h>
+#   if __BYTE_ORDER == __LITTLE_ENDIAN
+#       define PLATFORM_LITTLE_ENDIAN
+#   elif __BYTE_ORDER == __BIG_ENDIAN
+#       define PLATFORM_BIG_ENDIAN
+#   else
+#       error Unknown __BYTE_ORDER on endian.h
+#   endif
+#elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN) ||\
+      defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__) ||\
+      defined(_STLP_BIG_ENDIAN) && !defined(_STLP_LITTLE_ENDIAN)
+#       define PLATFORM_BIG_ENDIAN
+#elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN) ||\
+      defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__) ||\
+      defined(_STLP_LITTLE_ENDIAN) && !defined(_STLP_BIG_ENDIAN)
+#       define PLATFORM_LITTLE_ENDIAN
+#elif defined(__sparc) || defined(__sparc__) \
+   || defined(_POWER) || defined(__powerpc__) \
+   || defined(__ppc__) || defined(__hpux) || defined(__hppa) \
+   || defined(_MIPSEB) || defined(_POWER) \
+   || defined(__s390__)
+#       define PLATFORM_BIG_ENDIAN
+#elif defined(__i386__) || defined(__alpha__) \
+   || defined(__ia64) || defined(__ia64__) \
+   || defined(_M_IX86) || defined(_M_IA64) \
+   || defined(_M_ALPHA) || defined(__amd64) \
+   || defined(__amd64__) || defined(_M_AMD64) \
+   || defined(__x86_64) || defined(__x86_64__) \
+   || defined(_M_X64) || defined(__bfin__)
+#       define PLATFORM_LITTLE_ENDIAN
+#else
+#   error Unknown endianess.
+#endif
+
 
 #ifndef DLLEXP
 #	ifdef PLATFORM_WIN
@@ -52,7 +88,9 @@
 
 // Shortcuts for common types
 typedef signed char int8;
+typedef short int16;
 typedef unsigned short uint16;
+typedef int int32;
 typedef unsigned int uint32;
 typedef long long int64;
 typedef unsigned long long uint64;
@@ -80,7 +118,6 @@ typedef unsigned long long uint64;
 #if defined( _MSC_VER ) && (_MSC_VER < 1400)
 #   define vsnprintf _vsnprintf
 #endif
-
 
 // Runtime assertion
 #if defined( _DEBUG )


### PR DESCRIPTION
Fixes #25 
Though it needs to be tested on a big endian machine.

h3dutCreateGeometryRes and h3dutCreateTGAImage were changed but not tested _(unless Knight/Chicago/Terrain uses them?)_.

Also I couldn't test _ColladaConv_ output since I don't have any proper _.dae_ over here. Isn't there a source for the knight model?