### PR TITLE
Reorder vao and buffer deletion in GL4 backend

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egAnimation.cpp
+++ b/Horde3D/Source/Horde3DEngine/egAnimation.cpp
@@ -523,7 +523,7 @@ bool AnimationController::animate()
 
 int AnimationController::getAnimCount() const
 {
-    return _activeStages.size();
+    return ( int ) _activeStages.size();
 }
 
 

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -121,6 +121,9 @@ void GeometryResource::release()
 {
 	RenderDeviceInterface *rdi = Modules::renderer().getRenderDevice();
 
+	if ( _geoObj != 0 )
+		rdi->destroyGeometry( _geoObj, false );
+
 	if( _posVBuf != 0 && _posVBuf != defVertBuffer )
 		rdi->destroyBuffer( _posVBuf );
 	if( _tanVBuf != 0 && _tanVBuf != defVertBuffer )
@@ -130,9 +133,6 @@ void GeometryResource::release()
 	
 	if( _indexBuf != 0 && _indexBuf != defIndexBuffer )
 		rdi->destroyBuffer( _indexBuf );
-
-	if ( _geoObj != 0 )
-		rdi->destroyGeometry( _geoObj, false );
 
 	delete[] _indexData; _indexData = 0x0;
 	delete[] _vertPosData; _vertPosData = 0x0;

--- a/Horde3D/Source/Horde3DEngine/egGeometry.cpp
+++ b/Horde3D/Source/Horde3DEngine/egGeometry.cpp
@@ -78,6 +78,7 @@ Resource *GeometryResource::clone()
 	memcpy( res->_vertTanData, _vertTanData, _vertCount * sizeof( VertexDataTan ) );
 	memcpy( res->_vertStaticData, _vertStaticData, _vertCount * sizeof( VertexDataStatic ) );
 
+	res->_16BitIndices = _16BitIndices;
 	res->_geoObj = rdi->beginCreatingGeometry( Modules::renderer().getDefaultVertexLayout( DefaultVertexLayouts::Model ) );
 
 	res->_indexBuf = rdi->createIndexBuffer( _indexCount * (_16BitIndices ? 2 : 4), _indexData );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
@@ -78,6 +78,8 @@ struct RDIBufferGL2
 	uint32  type;
 	uint32  glObj;
 	uint32  size;
+
+	RDIBufferGL2() : type( 0 ), glObj( 0 ), size( 0 ) {}
 };
 
 struct RDIVertBufSlotGL2
@@ -116,6 +118,12 @@ struct RDITextureGL2
 	uint32                samplerState;
 	bool                  sRGB;
 	bool                  hasMips, genMips;
+
+	RDITextureGL2() : glObj( 0 ), glFmt( 0 ), type( 0 ), format( TextureFormats::Unknown ), width( 0 ), height( 0 ),
+		depth( 0 ), memSize( 0 ), samplerState( 0 ), sRGB( false ), hasMips( false ), genMips( false )
+	{
+
+	}
 };
 
 struct RDITexSlotGL2
@@ -133,6 +141,8 @@ struct RDITextureBufferGL2
 	uint32  bufObj;
 	uint32  glFmt;
 	uint32	glTexID;
+
+	RDITextureBufferGL2() : bufObj( 0 ), glFmt( 0 ), glTexID( 0 ) {}
 };
 
 // ---------------------------------------------------------
@@ -143,12 +153,22 @@ struct RDIInputLayoutGL2
 {
 	bool  valid;
 	int8  attribIndices[16];
+
+	RDIInputLayoutGL2() : valid( false )
+	{
+		memset( attribIndices, 0, sizeof( attribIndices ) );
+	}
 };
 
 struct RDIShaderGL2
 {
 	uint32				oglProgramObj;
 	RDIInputLayoutGL2	inputLayouts[MaxNumVertexLayouts];
+
+	RDIShaderGL2() : oglProgramObj( 0 )
+	{
+
+	}
 };
 
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -375,8 +375,9 @@ void RenderDeviceGL4::finishCreatingGeometry( uint32 geoObj )
 		}
 	}
 
-	glBindBuffer( GL_ARRAY_BUFFER, 0 );
 	glBindVertexArray( 0 );
+	glBindBuffer( GL_ARRAY_BUFFER, 0 );
+	glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 );
 }
 
 void RenderDeviceGL4::setGeomVertexParams( uint32 geoObj, uint32 vbo, uint32 vbSlot, uint32 offset, uint32 stride )

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -405,7 +405,10 @@ void RenderDeviceGL4::destroyGeometry( uint32& geoObj, bool destroyBindedBuffers
 		return;
 	
 	RDIGeometryInfoGL4 &curVao = _vaos.getRef( geoObj );
-	
+
+	glDeleteVertexArrays( 1, &curVao.vao );
+	glBindVertexArray( 0 );
+
 	if ( destroyBindedBuffers )
 	{
 		for ( unsigned int i = 0; i < curVao.vertexBufInfo.size(); ++i )
@@ -415,8 +418,6 @@ void RenderDeviceGL4::destroyGeometry( uint32& geoObj, bool destroyBindedBuffers
 
 		destroyBuffer( curVao.indexBuf );
 	}
-	
-	glDeleteVertexArrays( 1, &curVao.vao );
 
 	_vaos.remove( geoObj );
 	geoObj = 0;

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
@@ -64,6 +64,8 @@ struct RDIBufferGL4
 	uint32  type;
 	uint32  glObj;
 	uint32  size;
+
+	RDIBufferGL4() : type( 0 ), glObj( 0 ), size( 0 ) {}
 };
 
 struct RDIVertBufSlotGL4
@@ -115,6 +117,12 @@ struct RDITextureGL4
 	uint32                samplerState;
 	bool                  sRGB;
 	bool                  hasMips, genMips;
+
+	RDITextureGL4() : glObj( 0 ), glFmt( 0 ), type( 0 ), format( TextureFormats::Unknown ), width( 0 ), height( 0 ),
+					  depth( 0 ), memSize( 0 ), samplerState( 0 ), sRGB( false ), hasMips( false ), genMips( false )
+	{
+
+	}
 };
 
 struct RDITexSlotGL4
@@ -132,6 +140,8 @@ struct RDITextureBufferGL4
 	uint32  bufObj;
 	uint32  glFmt;
 	uint32	glTexID;
+
+	RDITextureBufferGL4() : bufObj( 0 ), glFmt( 0 ), glTexID( 0 ) {}
 };
 
 // ---------------------------------------------------------
@@ -142,12 +152,22 @@ struct RDIInputLayoutGL4
 {
 	bool  valid;
 	int8  attribIndices[16];
+
+	RDIInputLayoutGL4() : valid( false )
+	{
+		memset( attribIndices, 0, sizeof( attribIndices ) );
+	}
 };
 
 struct RDIShaderGL4
 {
 	uint32				oglProgramObj;
 	RDIInputLayoutGL4	inputLayouts[MaxNumVertexLayouts];
+
+	RDIShaderGL4() : oglProgramObj( 0 )
+	{
+		
+	}
 };
 
 

--- a/Horde3DEditor/src/HordeSceneEditorCore/CustomTypes.h
+++ b/Horde3DEditor/src/HordeSceneEditorCore/CustomTypes.h
@@ -132,7 +132,11 @@ struct Pipeline
 
 	QString		FileName;
     int         ResourceID;
-    Pipeline& operator=(const Pipeline& p) { if( ResourceID ) h3dRemoveResource(ResourceID); FileName = p.FileName; ResourceID = h3dAddResource(H3DResTypes::Pipeline, qPrintable(FileName), 0);}
+    Pipeline& operator=(const Pipeline& p) 
+	{ 
+		if( ResourceID ) h3dRemoveResource(ResourceID); FileName = p.FileName; ResourceID = h3dAddResource(H3DResTypes::Pipeline, qPrintable(FileName), 0);
+		return *this;
+	}
 	bool operator != (const Pipeline& other) const {return ResourceID != other.ResourceID || FileName != other.FileName;}	
 };
 Q_DECLARE_METATYPE(Pipeline)

--- a/Horde3DEditor/src/QPropertyEditor/Property.cpp
+++ b/Horde3DEditor/src/QPropertyEditor/Property.cpp
@@ -57,8 +57,8 @@ bool Property::isReadOnly()
         if( m_propertyObject->dynamicPropertyNames().contains( objectName().toLocal8Bit() ) )
             return false;
     }
-	else
-		return true;
+	
+	return true;
 }
 
 QWidget* Property::createEditor(QWidget *parent, const QStyleOptionViewItem& /*option*/)


### PR DESCRIPTION
Some implementations prefer VAO's to be deleted before buffers they refer to. May prevent crashes.