### PR TITLE
Implement reference counting for render device buffers

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egRenderer.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.cpp
@@ -76,9 +76,6 @@ Renderer::~Renderer()
 		releaseShaderComb( _defColorShader );
 
 		_renderDevice->destroyGeometry( _particleGeo );
-		// Particle and overlay share the index buffer,
-		// so avoid releasing the index buffer of _overlayGeo by setting it to zero
-		if( _overlayGeo ) _renderDevice->setGeomIndexParams( _overlayGeo, 0, IDXFMT_16 );
 		_renderDevice->destroyGeometry( _cubeGeo );
 		_renderDevice->destroyGeometry( _sphereGeo );
 		_renderDevice->destroyGeometry( _coneGeo );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -1066,13 +1066,13 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 		// Attach color buffers
 		for( uint32 j = 0; j < numColBufs; ++j )
 		{
-			glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, rb.fbo );
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, false, false, false, false );
 			ASSERT( texObj != 0 );
 			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
 			RDITextureGL2 &tex = _textures.getRef( texObj );
+			glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, rb.fbo );
 			// Attach the texture
 			glFramebufferTexture2DEXT( GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT + j, GL_TEXTURE_2D, tex.glObj, 0 );
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -195,7 +195,7 @@ void RenderDeviceGL2::initStates()
 	_defaultFBOMultisampled = value > 0;
 	GLboolean doubleBuffered;
 	glGetBooleanv( GL_DOUBLEBUFFER, &doubleBuffered );
-	_doubleBuffered = doubleBuffered;
+	_doubleBuffered = doubleBuffered != 0;
 	// Get the currently bound frame buffer object to avoid reset to invalid FBO
 	glGetIntegerv( GL_FRAMEBUFFER_BINDING_EXT, &_defaultFBO );
 }
@@ -342,7 +342,9 @@ void RenderDeviceGL2::finishCreatingGeometry( uint32 geoObj )
 void RenderDeviceGL2::setGeomVertexParams( uint32 geoObj, uint32 vbo, uint32 vbSlot, uint32 offset, uint32 stride )
 {
 	RDIGeometryInfoGL2 &geo = _geometryInfo.getRef( geoObj );
+	RDIBufferGL2 &buf = _buffers.getRef( vbo );
 
+	buf.geometryRefCount++;
 // 	if ( geo.vertexBufInfo.size() - 1 >= vbSlot )
 // 	{
 // 		// parameters found, change them
@@ -362,7 +364,9 @@ void RenderDeviceGL2::setGeomVertexParams( uint32 geoObj, uint32 vbo, uint32 vbS
 void RenderDeviceGL2::setGeomIndexParams( uint32 geoObj, uint32 indBuf, RDIIndexFormat format )
 {
 	RDIGeometryInfoGL2 &geo = _geometryInfo.getRef( geoObj );
+	RDIBufferGL2 &buf = _buffers.getRef( indBuf );
 
+	buf.geometryRefCount++;
 	geo.indexBufIdx = indBuf;
 	geo.indexBuf32Bit = format == IDXFMT_32 ? true : false;
 }
@@ -378,25 +382,50 @@ void RenderDeviceGL2::destroyGeometry( uint32& geoObj, bool destroyBindedBuffers
 	{
 		for ( unsigned int i = 0; i < geo.vertexBufInfo.size(); ++i )
 		{
+			decreaseBufferRefCount( geo.vertexBufInfo[ i ].vbObj );
 			destroyBuffer( geo.vertexBufInfo[ i ].vbObj );
 		}
 
+		decreaseBufferRefCount( geo.indexBufIdx );
 		destroyBuffer( geo.indexBufIdx );
+	}
+	else
+	{
+		// just decrease reference count
+		for ( unsigned int i = 0; i < geo.vertexBufInfo.size(); ++i )
+		{
+			decreaseBufferRefCount( geo.vertexBufInfo[ i ].vbObj );
+		}
+
+		decreaseBufferRefCount( geo.indexBufIdx );
 	}
 	
 	_geometryInfo.remove( geoObj );
 	geoObj = 0;
 }
 
+
+void RenderDeviceGL2::decreaseBufferRefCount( uint32 bufObj )
+{
+	if ( bufObj == 0 ) return;
+
+	RDIBufferGL2 &buf = _buffers.getRef( bufObj );
+
+	buf.geometryRefCount--;
+}
+
+
 uint32 RenderDeviceGL2::createVertexBuffer( uint32 size, const void *data )
 {
 	return createBuffer( GL_ARRAY_BUFFER, size, data );
 }
 
+
 uint32 RenderDeviceGL2::createIndexBuffer( uint32 size, const void *data )
 {
 	return createBuffer( GL_ELEMENT_ARRAY_BUFFER, size, data );;
 }
+
 
 uint32 RenderDeviceGL2::createTextureBuffer( TextureFormats::List format, uint32 bufSize, const void *data )
 {
@@ -440,6 +469,7 @@ uint32 RenderDeviceGL2::createTextureBuffer( TextureFormats::List format, uint32
 	return _textureBuffs.add( buf );
 }
 
+
 uint32 RenderDeviceGL2::createShaderStorageBuffer( uint32 size, const void *data )
 {
 	H3D_UNUSED_VAR( size );
@@ -449,6 +479,7 @@ uint32 RenderDeviceGL2::createShaderStorageBuffer( uint32 size, const void *data
 
 	return 0;
 }
+
 
 uint32 RenderDeviceGL2::createBuffer( uint32 bufType, uint32 size, const void *data )
 {
@@ -465,24 +496,30 @@ uint32 RenderDeviceGL2::createBuffer( uint32 bufType, uint32 size, const void *d
 	return _buffers.add( buf );
 }
 
+
 void RenderDeviceGL2::destroyBuffer( uint32& bufObj )
 {
 	if( bufObj == 0 )
 		return;
 	
 	RDIBufferGL2 &buf = _buffers.getRef( bufObj );
-	glDeleteBuffers( 1, &buf.glObj );
 
-	_bufferMem -= buf.size;
-	_buffers.remove( bufObj );
-	bufObj = 0;
+	if ( buf.geometryRefCount < 1 )
+	{
+		glDeleteBuffers( 1, &buf.glObj );
+
+		_bufferMem -= buf.size;
+		_buffers.remove( bufObj );
+		bufObj = 0;
+	}
 }
 
 
 void RenderDeviceGL2::destroyTextureBuffer( uint32& bufObj )
 {
-
+	
 }
+
 
 void RenderDeviceGL2::updateBufferData( uint32 geoObj, uint32 bufObj, uint32 offset, uint32 size, void *data )
 {
@@ -501,6 +538,7 @@ void RenderDeviceGL2::updateBufferData( uint32 geoObj, uint32 bufObj, uint32 off
 	glBufferSubData( buf.type, offset, size, data );
 }
 
+
 void * RenderDeviceGL2::mapBuffer( uint32 geoObj, uint32 bufObj, uint32 offset, uint32 size, RDIBufferMappingTypes mapType )
 {
 	const RDIBufferGL2 &buf = _buffers.getRef( bufObj );
@@ -510,6 +548,7 @@ void * RenderDeviceGL2::mapBuffer( uint32 geoObj, uint32 bufObj, uint32 offset, 
 
 	return glMapBuffer( buf.type, bufferMappingTypes[ mapType ] );
 }
+
 
 void RenderDeviceGL2::unmapBuffer( uint32 geoObj, uint32 bufObj )
 {

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
@@ -75,8 +75,9 @@ struct RDIBufferGL2
 	uint32  type;
 	uint32  glObj;
 	uint32  size;
+	int		geometryRefCount;
 
-	RDIBufferGL2() : type( 0 ), glObj( 0 ), size( 0 ) {}
+	RDIBufferGL2() : type( 0 ), glObj( 0 ), size( 0 ), geometryRefCount( 0 ) {}
 };
 
 struct RDIVertBufSlotGL2
@@ -329,6 +330,8 @@ protected:
 	bool applyVertexLayout( const RDIGeometryInfoGL2 &geo );
 	void applySamplerState( RDITextureGL2 &tex );
 	void applyRenderStates();
+
+	inline void	  decreaseBufferRefCount( uint32 bufObj );
 
 protected:
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -202,7 +202,7 @@ void RenderDeviceGL4::initStates()
 	_defaultFBOMultisampled = value > 0;
 	GLboolean doubleBuffered;
 	glGetBooleanv( GL_DOUBLEBUFFER, &doubleBuffered );
-	_doubleBuffered = doubleBuffered;
+	_doubleBuffered = doubleBuffered != 0;
 	// Get the currently bound frame buffer object to avoid reset to invalid FBO
 	glGetIntegerv( GL_FRAMEBUFFER_BINDING_EXT, &_defaultFBO );
 }
@@ -401,6 +401,9 @@ void RenderDeviceGL4::finishCreatingGeometry( uint32 geoObj )
 void RenderDeviceGL4::setGeomVertexParams( uint32 geoObj, uint32 vbo, uint32 vbSlot, uint32 offset, uint32 stride )
 {
 	RDIGeometryInfoGL4 &curVao = _vaos.getRef( geoObj );
+	RDIBufferGL4 &buf = _buffers.getRef( vbo );
+
+	buf.geometryRefCount++;
 
 	RDIVertBufSlotGL4 attribInfo;
 	attribInfo.vbObj = vbo;
@@ -413,7 +416,9 @@ void RenderDeviceGL4::setGeomVertexParams( uint32 geoObj, uint32 vbo, uint32 vbS
 void RenderDeviceGL4::setGeomIndexParams( uint32 geoObj, uint32 indBuf, RDIIndexFormat format )
 {
 	RDIGeometryInfoGL4 &curVao = _vaos.getRef( geoObj );
+	RDIBufferGL4 &buf = _buffers.getRef( indBuf );
 
+	buf.geometryRefCount++;
 	curVao.indexBuf = indBuf;
 	curVao.indexBuf32Bit = ( format == IDXFMT_32 ? true : false );
 }
@@ -432,15 +437,36 @@ void RenderDeviceGL4::destroyGeometry( uint32& geoObj, bool destroyBindedBuffers
 	{
 		for ( unsigned int i = 0; i < curVao.vertexBufInfo.size(); ++i )
 		{
+			decreaseBufferRefCount( curVao.vertexBufInfo[ i ].vbObj );
 			destroyBuffer( curVao.vertexBufInfo[ i ].vbObj );
 		}
 
+		decreaseBufferRefCount( curVao.indexBuf );
 		destroyBuffer( curVao.indexBuf );
+	}
+	else
+	{
+		for ( size_t i = 0; i < curVao.vertexBufInfo.size(); ++i )
+		{
+			decreaseBufferRefCount( curVao.vertexBufInfo[ i ].vbObj );
+		}
+		decreaseBufferRefCount( curVao.indexBuf );
 	}
 
 	_vaos.remove( geoObj );
 	geoObj = 0;
 }
+
+
+void RenderDeviceGL4::decreaseBufferRefCount( uint32 bufObj )
+{
+	if ( bufObj == 0 ) return;
+	
+	RDIBufferGL4 &buf = _buffers.getRef( bufObj );
+
+	buf.geometryRefCount--;
+}
+
 
 uint32 RenderDeviceGL4::createVertexBuffer( uint32 size, const void *data )
 {
@@ -532,11 +558,15 @@ void RenderDeviceGL4::destroyBuffer( uint32& bufObj )
 		return;
 	
 	RDIBufferGL4 &buf = _buffers.getRef( bufObj );
-	glDeleteBuffers( 1, &buf.glObj );
 
-	_bufferMem -= buf.size;
-	_buffers.remove( bufObj );
-	bufObj = 0;
+	if ( buf.geometryRefCount < 1 )
+	{
+		glDeleteBuffers( 1, &buf.glObj );
+
+		_bufferMem -= buf.size;
+		_buffers.remove( bufObj );
+		bufObj = 0;
+	}
 }
 
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -1293,13 +1293,13 @@ uint32 RenderDeviceGL4::createRenderBuffer( uint32 width, uint32 height, Texture
 		// Attach color buffers
 		for( uint32 j = 0; j < numColBufs; ++j )
 		{
-			glBindFramebuffer( GL_FRAMEBUFFER, rb.fbo );
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, false, false, false, false );
 			ASSERT( texObj != 0 );
 			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
 			RDITextureGL4 &tex = _textures.getRef( texObj );
+			glBindFramebuffer( GL_FRAMEBUFFER, rb.fbo );
 			// Attach the texture
 			glFramebufferTexture2D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + j, GL_TEXTURE_2D, tex.glObj, 0 );
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
@@ -63,8 +63,9 @@ struct RDIBufferGL4
 	uint32  type;
 	uint32  glObj;
 	uint32  size;
+	int		geometryRefCount;
 
-	RDIBufferGL4() : type( 0 ), glObj( 0 ), size( 0 ) {}
+	RDIBufferGL4() : type( 0 ), glObj( 0 ), size( 0 ), geometryRefCount( 0 ) {}
 };
 
 struct RDIVertBufSlotGL4
@@ -329,6 +330,7 @@ protected:
 
 	inline uint32 createBuffer( uint32 type, uint32 size, const void *data );
 
+	inline void	  decreaseBufferRefCount( uint32 bufObj );
 protected:
 
 	RDIVertexLayout                    _vertexLayouts[MaxNumVertexLayouts];


### PR DESCRIPTION
Now buffers can safely be shared between different geometry objects. Functionality tested on terrain sample, knight sample and editor.