### PR TITLE
Fix null deref when glGetString(GL_EXTENSIONS) == NULL

### DIFF
--- a/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
+++ b/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
@@ -561,6 +561,11 @@ bool isExtensionSupported( const char *extName )
 	if( glExt::majorVersion < 3 )
 	{
 		const char *extensions = (char *)glGetString( GL_EXTENSIONS );
+                if( extensions == 0x0 )
+                {
+                    return false;
+                }
+
 		size_t nameLen = strlen( extName );
 		const char *pos;
 		while( ( pos = strstr( extensions, extName ) ) != 0x0 )


### PR DESCRIPTION
When using a core profile OpenGL 4.1 context on macOS,
EXT_texture_sRGB is not listed. This causes Horde3D to
fall back to OpenGL 2.1, but without switching the context profile.

I'm not clear on the semantics of an OpenGL 2.1 core profile
context on macOS or how that's possible, but
glGetString(GL_EXTENSIONS) returns NULL.