### PR TITLE
Fix incorrect joint count limit and unnecessary extension removed in GL4 backend

### DIFF
--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -464,7 +464,9 @@ void Converter::processJoints()
 		_joints[i]->invBindMat = _joints[i]->matAbs.inverted();
 	}
 
-	if( _joints.size() + 1 > 75 ) log( "Warning: Model has more than 75 joints" );
+	if( _joints.size() + 1 > 75 ) log( "Warning: Model has more than 75 joints. It may render incorrectly if used with OpenGL 2 render backend." );
+	if ( _joints.size() + 1 > 330 ) log( "Warning: Model has more than 330 joints. Currently it is not supported." );
+
 }
 
 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -250,12 +250,7 @@ bool RenderDeviceGL4::init()
 		Modules::log().writeError( "Extension EXT_texture_compression_s3tc not supported" );
 		failed = true;
 	}
-	if( !glExt::EXT_texture_sRGB )
-	{
-		Modules::log().writeError( "Extension EXT_texture_sRGB not supported" );
-		failed = true;
-	}
-	
+		
 	if( failed )
 	{
 		Modules::log().writeError( "Failed to init renderer backend (OpenGL %d.%d), retrying with legacy OpenGL 2.1 backend", 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -269,7 +269,7 @@ bool RenderDeviceGL4::init()
 	_caps.tesselation = glExt::majorVersion >= 4 && glExt::minorVersion >= 1;
 	_caps.computeShaders = glExt::majorVersion >= 4 && glExt::minorVersion >= 3;
 	_caps.instancing = true;
-	_caps.maxJointCount = 75; // currently, will be changed soon
+	_caps.maxJointCount = 330;
 	_caps.maxTexUnitCount = 96; // for most modern hardware it is 192 (GeForce 400+, Radeon 7000+, Intel 4000+). Although 96 should probably be enough.
 
 	// Find maximum number of storage buffers in compute shader

--- a/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
+++ b/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
@@ -695,6 +695,8 @@ void initLegacyExtensions( bool &r )
 	{
 		r &= ( glTexBufferARB = ( PFNGLTEXBUFFERPROC ) platGetProcAddress( "glTexBuffer" ) ) != 0x0;
 	}
+
+	glExt::EXT_texture_sRGB = isExtensionSupported( "GL_EXT_texture_sRGB" );
 }
 
 void initModernExtensions( bool &r )
@@ -1241,8 +1243,6 @@ bool initOpenGLExtensions( bool forceLegacyFuncs )
 	glExt::EXT_texture_filter_anisotropic = isExtensionSupported( "GL_EXT_texture_filter_anisotropic" );
 
 	glExt::EXT_texture_compression_s3tc = isExtensionSupported( "GL_EXT_texture_compression_s3tc" ) || isExtensionSupported( "GL_S3_s3tc" );
-
-	glExt::EXT_texture_sRGB = isExtensionSupported( "GL_EXT_texture_sRGB" );
 
 	return r;
 }


### PR DESCRIPTION
Incorrect joint count limit was reported by GL4 backend (reported in #103, already fixed in develop, but should probably be in master too). EXT_texture_sRGB was loaded in GL4 backend, but is not necessary, as its functionality became core in OpenGL 3 and can lead to problems in macOS (as shown by #106)