### PR TITLE
Renderable texture with depth buffer, partial mip map and xml error handling

### DIFF
--- a/Horde3D/Bindings/C++/Horde3D.h
+++ b/Horde3D/Bindings/C++/Horde3D.h
@@ -233,9 +233,10 @@ struct H3DResFlags
 		NoTexMipmaps      - Disables generation of mipmaps for Texture resource.
 		TexCubemap        - Sets Texture resource to be a cubemap.
 		TexDynamic        - Enables more efficient updates of Texture resource streams.
-		TexRenderable     - Makes Texture resource usable as render target.
 		TexSRGB           - Indicates that Texture resource is in sRGB color space and should be converted
 		                    to linear space when being sampled.
+		TexRenderable     - Makes Texture resource usable as render target.
+		TexDepthBuffer    - When Textures is renderable, creates a depth buffer along with the color buffer.
 	*/
 	enum Flags
 	{
@@ -244,8 +245,9 @@ struct H3DResFlags
 		NoTexMipmaps = 4,
 		TexCubemap = 8,
 		TexDynamic = 16,
-		TexRenderable = 32,
-		TexSRGB = 64
+		TexSRGB = 32,
+		TexRenderable = 64,
+		TexDepthBuffer = 128,
 	};
 };
 

--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 // little endian element writer

--- a/Horde3D/Source/ColladaConverter/converter.h
+++ b/Horde3D/Source/ColladaConverter/converter.h
@@ -18,7 +18,7 @@
 #include <string.h> // memset
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct Joint;

--- a/Horde3D/Source/ColladaConverter/daeCommon.h
+++ b/Horde3D/Source/ColladaConverter/daeCommon.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeSource

--- a/Horde3D/Source/ColladaConverter/daeLibAnimations.h
+++ b/Horde3D/Source/ColladaConverter/daeLibAnimations.h
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeSampler

--- a/Horde3D/Source/ColladaConverter/daeLibControllers.h
+++ b/Horde3D/Source/ColladaConverter/daeLibControllers.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeWeight

--- a/Horde3D/Source/ColladaConverter/daeLibEffects.h
+++ b/Horde3D/Source/ColladaConverter/daeLibEffects.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeEffect

--- a/Horde3D/Source/ColladaConverter/daeLibGeometries.h
+++ b/Horde3D/Source/ColladaConverter/daeLibGeometries.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeVSource

--- a/Horde3D/Source/ColladaConverter/daeLibImages.h
+++ b/Horde3D/Source/ColladaConverter/daeLibImages.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeImage

--- a/Horde3D/Source/ColladaConverter/daeLibMaterials.h
+++ b/Horde3D/Source/ColladaConverter/daeLibMaterials.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeMaterial

--- a/Horde3D/Source/ColladaConverter/daeLibNodes.h
+++ b/Horde3D/Source/ColladaConverter/daeLibNodes.h
@@ -19,7 +19,7 @@
 #include "daeLibVisualScenes.h"
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeLibNodes

--- a/Horde3D/Source/ColladaConverter/daeLibVisualScenes.h
+++ b/Horde3D/Source/ColladaConverter/daeLibVisualScenes.h
@@ -20,7 +20,7 @@
 #include <map>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct DaeTransformation

--- a/Horde3D/Source/ColladaConverter/daeMain.cpp
+++ b/Horde3D/Source/ColladaConverter/daeMain.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 ColladaDocument::ColladaDocument()

--- a/Horde3D/Source/ColladaConverter/daeMain.h
+++ b/Horde3D/Source/ColladaConverter/daeMain.h
@@ -24,7 +24,7 @@
 #include "daeLibNodes.h"
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 class ColladaDocument

--- a/Horde3D/Source/ColladaConverter/main.cpp
+++ b/Horde3D/Source/ColladaConverter/main.cpp
@@ -31,7 +31,7 @@
 
 using namespace std;
 using namespace Horde3D;
-using namespace ColladaConnverter;
+using namespace ColladaConverter;
 
 
 struct AssetTypes

--- a/Horde3D/Source/ColladaConverter/optimizer.cpp
+++ b/Horde3D/Source/ColladaConverter/optimizer.cpp
@@ -18,7 +18,7 @@
 
 using namespace std;
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 void OptVertex::updateScore( int cacheIndex )

--- a/Horde3D/Source/ColladaConverter/optimizer.h
+++ b/Horde3D/Source/ColladaConverter/optimizer.h
@@ -18,7 +18,7 @@
 #include <map>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 struct TriGroup;

--- a/Horde3D/Source/ColladaConverter/utils.cpp
+++ b/Horde3D/Source/ColladaConverter/utils.cpp
@@ -28,7 +28,7 @@
 
 using namespace std;
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 void removeGate( string &s )

--- a/Horde3D/Source/ColladaConverter/utils.h
+++ b/Horde3D/Source/ColladaConverter/utils.h
@@ -20,7 +20,7 @@
 #include <string>
 
 namespace Horde3D {
-namespace ColladaConnverter {
+namespace ColladaConverter {
 
 
 void removeGate( std::string &s );

--- a/Horde3D/Source/Horde3DEngine/CMakeLists.txt
+++ b/Horde3D/Source/Horde3DEngine/CMakeLists.txt
@@ -94,6 +94,11 @@ add_library(Horde3D SHARED
 	${HORDE3D_SOURCES}
 	)
 
+option(RAPIDXML_NO_EXCEPTIONS "Disabling rapidxml exceptions will terminating application on xml parsing error" ON)
+if (RAPIDXML_NO_EXCEPTIONS)
+	add_definitions(-DRAPIDXML_NO_EXCEPTIONS)
+endif(RAPIDXML_NO_EXCEPTIONS)
+
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	IF(MSVC)

--- a/Horde3D/Source/Horde3DEngine/egPipeline.cpp
+++ b/Horde3D/Source/Horde3DEngine/egPipeline.cpp
@@ -338,7 +338,7 @@ bool PipelineResource::createRenderTargets()
 		if( height == 0 ) height = ftoi_r( _baseHeight * rt.scale );
 		
 		rt.rendBuf = rdi->createRenderBuffer(
-			width, height, rt.format, rt.hasDepthBuf, rt.numColBufs, rt.samples, false );
+			width, height, rt.format, rt.hasDepthBuf, rt.numColBufs, rt.samples, 0 );
 		if( rt.rendBuf == 0 ) return false;
 	}
 	

--- a/Horde3D/Source/Horde3DEngine/egRenderer.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.cpp
@@ -272,7 +272,7 @@ bool Renderer::init( RenderBackendType::List type )
 
 	// Create default shadow map
 	float shadowTex[16] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
-	_defShadowMap = _renderDevice->createTexture( TextureTypes::Tex2D, 4, 4, 1, TextureFormats::DEPTH, false, false, false, false );
+	_defShadowMap = _renderDevice->createTexture( TextureTypes::Tex2D, 4, 4, 1, TextureFormats::DEPTH, 0, false, false, false );
 	_renderDevice->uploadTextureData( _defShadowMap, 0, 0, shadowTex );
 
 	// Create index buffer used for drawing particles
@@ -757,7 +757,7 @@ bool Renderer::setMaterialRec( MaterialResource *materialRes, const string &shad
 		{
 			if( materialRes->_samplers[j].name == sampler.id )
 			{
-                if( materialRes->_samplers[j].texRes && materialRes->_samplers[j].texRes->isLoaded() )
+				if( materialRes->_samplers[j].texRes && materialRes->_samplers[j].texRes->isLoaded() )
 					texRes = materialRes->_samplers[j].texRes;
 				break;
 			}
@@ -927,7 +927,7 @@ bool Renderer::setMaterial( MaterialResource *materialRes, const string &shaderC
 
 bool Renderer::createShadowRB( uint32 width, uint32 height )
 {
-	_shadowRB = _renderDevice->createRenderBuffer( width, height, TextureFormats::BGRA8, true, 0, 0, false );
+	_shadowRB = _renderDevice->createRenderBuffer( width, height, TextureFormats::BGRA8, true, 0, 0, 0 );
 	
 	return _shadowRB != 0;
 }
@@ -2075,7 +2075,7 @@ void Renderer::drawComputeResults( uint32 firstItem, uint32 lastItem, const std:
 		}
 		
 		// Wait for completion of compute operation (writing to buffer)
-        rdi->setMemoryBarrier( VertexBufferBarrier );
+		rdi->setMemoryBarrier( VertexBufferBarrier );
 
 		// Render
 		rdi->draw( drawType, 0, compNode->_elementsCount );
@@ -2211,7 +2211,7 @@ void Renderer::render( CameraNode *camNode )
 	}
 	
 	// Update mipmaps if necessary
-	if( _curCamera->_outputTex != 0x0 && _curCamera->_outputTex->hasMipMaps() )
+	if( _curCamera->_outputTex != 0x0 && _curCamera->_outputTex->getMaxMipLevel() > 0 )
 		_renderDevice->generateTextureMipmap( _curCamera->_outputTex->getTexObject() );
 
 	finishRendering();
@@ -2258,7 +2258,7 @@ void Renderer::renderDebugView()
 	setShaderComb( &_defColorShader );
 	commitGeneralUniforms();
 	
-    Matrix4f identity;
+	Matrix4f identity;
 	_renderDevice->setShaderConst( _defColorShader.uniLocs[ _uni.worldMat ], CONST_FLOAT44, &identity.x[0] );
 	color[0] = 0.4f; color[1] = 0.4f; color[2] = 0.4f; color[3] = 1;
 	_renderDevice->setShaderConst( Modules::renderer()._defColShader_color, CONST_FLOAT4, color );

--- a/Horde3D/Source/Horde3DEngine/egRendererBase.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBase.h
@@ -515,7 +515,7 @@ protected:
 	RDIDelegate< void* ( uint32, uint32, uint32, uint32, RDIBufferMappingTypes ) > _delegate_mapBuffer;
 	RDIDelegate< void ( uint32, uint32 ) >								_delegate_unmapBuffer;
 
-	RDIDelegate< uint32 ( TextureTypes::List, int, int, int, TextureFormats::List, bool, bool, bool, bool ) > _delegate_createTexture;
+	RDIDelegate< uint32 ( TextureTypes::List, int, int, int, TextureFormats::List, int, bool, bool, bool ) > _delegate_createTexture;
 	RDIDelegate< void ( uint32 ) >										_delegate_generateTextureMipmap;
 	RDIDelegate< void ( uint32, int, int, const void * ) >				_delegate_uploadTextureData;
 	RDIDelegate< void ( uint32 & ) >									_delegate_destroyTexture;
@@ -535,7 +535,7 @@ protected:
 	RDIDelegate< const char *() >										_delegate_getDefaultVSCode;
 	RDIDelegate< const char *() >										_delegate_getDefaultFSCode;
 
-	RDIDelegate< uint32 ( uint32, uint32, TextureFormats::List, bool, uint32, uint32, bool ) > _delegate_createRenderBuffer;
+	RDIDelegate< uint32 ( uint32, uint32, TextureFormats::List, bool, uint32, uint32, uint32 ) > _delegate_createRenderBuffer;
 	RDIDelegate< void ( uint32 & ) >									_delegate_destroyRenderBuffer;
 	RDIDelegate< uint32( uint32, uint32 ) >								_delegate_getRenderBufferTex;
 	RDIDelegate< void ( uint32 ) >										_delegate_setRenderBuffer;
@@ -710,10 +710,21 @@ public:
 				return 0;
 		}
 	}
+	uint32 calcTextureSize( TextureFormats::List format, int width, int height, int depth, int maxMipLevel )
+	{
+		uint32 size = 0;
+		for ( int level = 0; level <= maxMipLevel; ++level ) {
+			size += calcTextureSize(format, width, height, depth);
+			if ( width > 1 ) width >>= 1;
+			if ( height > 1 ) height >>= 1;
+			if ( depth > 1 ) depth >>= 1;
+		}
+		return size;
+	}
 	uint32 createTexture( TextureTypes::List type, int width, int height, int depth, TextureFormats::List format,
-	                      bool hasMips, bool genMips, bool compress, bool sRGB )
-	{ 
-		return _delegate_createTexture.invoke( type, width, height, depth, format, hasMips, genMips, compress, sRGB );
+	                      int maxMipLevel, bool genMips, bool compress, bool sRGB )
+	{
+		return _delegate_createTexture.invoke( type, width, height, depth, format, maxMipLevel, genMips, compress, sRGB );
 	}
 	void generateTextureMipmap( uint32 texObj )
 	{
@@ -798,12 +809,12 @@ public:
 
 	// Renderbuffers
 	uint32 createRenderBuffer( uint32 width, uint32 height, TextureFormats::List format,
-	                           bool depth, uint32 numColBufs, uint32 samples, bool hasMipmaps )
+	                           bool depth, uint32 numColBufs, uint32 samples, uint32 maxMipLevel )
 	{
-		return _delegate_createRenderBuffer.invoke( width, height, format, depth, numColBufs, samples, hasMipmaps);
+		return _delegate_createRenderBuffer.invoke( width, height, format, depth, numColBufs, samples, maxMipLevel);
 	}
     void destroyRenderBuffer( uint32& rbObj )
-	{ 
+	{
 		_delegate_destroyRenderBuffer.invoke( rbObj );
 	}
 	uint32 getRenderBufferTex( uint32 rbObj, uint32 bufIndex ) 

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -697,8 +697,8 @@ void RenderDeviceGL2::unmapBuffer( uint32 geoObj, uint32 bufObj )
 // =================================================================================================
 
 uint32 RenderDeviceGL2::createTexture( TextureTypes::List type, int width, int height, int depth,
-                                    TextureFormats::List format,
-                                    bool hasMips, bool genMips, bool compress, bool sRGB )
+                                       TextureFormats::List format,
+                                       int maxMipLevel, bool genMips, bool compress, bool sRGB )
 {
 	ASSERT( depth > 0 );
 
@@ -732,7 +732,7 @@ uint32 RenderDeviceGL2::createTexture( TextureTypes::List type, int width, int h
 	tex.depth = depth;
 	tex.sRGB = sRGB && Modules::config().sRGBLinearization;
 	tex.genMips = genMips;
-	tex.hasMips = hasMips;
+	tex.hasMips = maxMipLevel > 0;
 
 	if ( format > ( int ) textureGLFormats.size() ) { ASSERT( 0 ); return 0; }
 
@@ -743,7 +743,9 @@ uint32 RenderDeviceGL2::createTexture( TextureTypes::List type, int width, int h
 	glGenTextures( 1, &tex.glObj );
 	glActiveTexture( GL_TEXTURE15 );
 	glBindTexture( tex.type, tex.glObj );
-	
+
+	glTexParameteri( tex.type, GL_TEXTURE_MAX_LEVEL, maxMipLevel );
+
 	float borderColor[] = { 1.0f, 1.0f, 1.0f, 1.0f };
 	glTexParameterfv( tex.type, GL_TEXTURE_BORDER_COLOR, borderColor );
 	
@@ -755,8 +757,7 @@ uint32 RenderDeviceGL2::createTexture( TextureTypes::List type, int width, int h
 		glBindTexture( _textures.getRef( _texSlots[15].texObj ).type, _textures.getRef( _texSlots[15].texObj ).glObj );
 
 	// Calculate memory requirements
-	tex.memSize = calcTextureSize( format, width, height, depth );
-	if( hasMips || genMips ) tex.memSize += ftoi_r( tex.memSize * 1.0f / 3.0f );
+	tex.memSize = calcTextureSize( format, width, height, depth, maxMipLevel );
 	if( type == TextureTypes::TexCube ) tex.memSize *= 6;
 	_textureMem += tex.memSize;
 	
@@ -1186,7 +1187,7 @@ void RenderDeviceGL2::runComputeShader( uint32 shaderId, uint32 xDim, uint32 yDi
 // =================================================================================================
 
 uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, TextureFormats::List format,
-                                            bool depth, uint32 numColBufs, uint32 samples, bool hasMipmaps )
+                                            bool depth, uint32 numColBufs, uint32 samples, uint32 maxMipLevel )
 {
 	if( (format == TextureFormats::RGBA16F || format == TextureFormats::RGBA32F) && !_caps.texFloat )
 	{
@@ -1223,7 +1224,7 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 		for( uint32 j = 0; j < numColBufs; ++j )
 		{
 			// Create a color texture
-			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, hasMipmaps, hasMipmaps, false, false );
+			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, maxMipLevel, maxMipLevel > 0, false, false );
 			ASSERT( texObj != 0 );
 			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
@@ -1275,7 +1276,7 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 	{
 		glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, rb.fbo );
 		// Create a depth texture
-		uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, false, false, false, false );
+		uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, 0, false, false, false );
 		ASSERT( texObj != 0 );
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE );
 		uploadTextureData( texObj, 0, 0, 0x0 );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -745,7 +745,7 @@ uint32 RenderDeviceGL2::createTexture( TextureTypes::List type, int width, int h
 	glBindTexture( tex.type, tex.glObj );
 	
 	float borderColor[] = { 1.0f, 1.0f, 1.0f, 1.0f };
-	glTexParameterfv( GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor );
+	glTexParameterfv( tex.type, GL_TEXTURE_BORDER_COLOR, borderColor );
 	
 	tex.samplerState = 0;
 	applySamplerState( tex );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.h
@@ -238,7 +238,7 @@ public:
 	// Textures
 // 	uint32 calcTextureSize( TextureFormats::List format, int width, int height, int depth );
 	uint32 createTexture( TextureTypes::List type, int width, int height, int depth, TextureFormats::List format,
-	                      bool hasMips, bool genMips, bool compress, bool sRGB );
+	                      int maxMipLevel, bool genMips, bool compress, bool sRGB );
 	void generateTextureMipmap( uint32 texObj );
 	void uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels );
 	void destroyTexture( uint32& texObj );
@@ -264,7 +264,7 @@ public:
 
 	// Renderbuffers
 	uint32 createRenderBuffer( uint32 width, uint32 height, TextureFormats::List format,
-	                           bool depth, uint32 numColBufs, uint32 samples, bool hasMipmaps );
+	                           bool depth, uint32 numColBufs, uint32 samples, uint32 maxMipLevel );
 	void destroyRenderBuffer(uint32 &rbObj );
 	uint32 getRenderBufferTex( uint32 rbObj, uint32 bufIndex );
 	void setRenderBuffer( uint32 rbObj );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -2180,8 +2180,9 @@ void RenderDeviceGL4::resetStates()
 	_pendingMask = 0xFFFFFFFF;
 	commitStates();
 
+	glEnable( GL_TEXTURE_CUBE_MAP_SEAMLESS );
 //	glBindVertexArray( 0 );
- 	glBindBuffer( GL_ARRAY_BUFFER, 0 );
+	glBindBuffer( GL_ARRAY_BUFFER, 0 );
 	glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, 0 );
 
 	glBindFramebuffer( GL_FRAMEBUFFER, _defaultFBO );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -821,7 +821,7 @@ uint32 RenderDeviceGL4::createTexture( TextureTypes::List type, int width, int h
 	glBindTexture( tex.type, tex.glObj );
 	
 	float borderColor[] = { 1.0f, 1.0f, 1.0f, 1.0f };
-	glTexParameterfv( GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor );
+	glTexParameterfv( tex.type, GL_TEXTURE_BORDER_COLOR, borderColor );
 	
 	tex.samplerState = 0;
 	applySamplerState( tex );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.h
@@ -232,7 +232,7 @@ public:
 	// Textures
 // 	uint32 calcTextureSize( TextureFormats::List format, int width, int height, int depth );
 	uint32 createTexture( TextureTypes::List type, int width, int height, int depth, TextureFormats::List format,
-	                      bool hasMips, bool genMips, bool compress, bool sRGB );
+	                      int maxMipLevel, bool genMips, bool compress, bool sRGB );
 	void generateTextureMipmap( uint32 texObj );
 	void uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels );
 	void destroyTexture( uint32 &texObj );
@@ -258,7 +258,7 @@ public:
 
 	// Renderbuffers
 	uint32 createRenderBuffer( uint32 width, uint32 height, TextureFormats::List format,
-	                           bool depth, uint32 numColBufs, uint32 samples, bool hasMipmaps );
+	                           bool depth, uint32 numColBufs, uint32 samples, uint32 maxMipLevel );
 	void destroyRenderBuffer(uint32 &rbObj );
 	uint32 getRenderBufferTex( uint32 rbObj, uint32 bufIndex );
 	void setRenderBuffer( uint32 rbObj );

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGLES3.h
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGLES3.h
@@ -215,7 +215,7 @@ public:
 	// Textures
 // 	uint32 calcTextureSize( TextureFormats::List format, int width, int height, int depth );
 	uint32 createTexture( TextureTypes::List type, int width, int height, int depth, TextureFormats::List format,
-	                      bool hasMips, bool genMips, bool compress, bool sRGB );
+	                      int maxMipLevel, bool genMips, bool compress, bool sRGB );
 	void generateTextureMipmap( uint32 texObj );
 	void uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels );
 	void destroyTexture( uint32 &texObj );
@@ -241,7 +241,7 @@ public:
 
 	// Renderbuffers
 	uint32 createRenderBuffer( uint32 width, uint32 height, TextureFormats::List format,
-	                           bool depth, uint32 numColBufs, uint32 samples, bool hasMipmaps );
+	                           bool depth, uint32 numColBufs, uint32 samples, uint32 maxMipLevel );
 	void destroyRenderBuffer( uint32 &rbObj );
 	uint32 getRenderBufferTex( uint32 rbObj, uint32 bufIndex );
 	void setRenderBuffer( uint32 rbObj );

--- a/Horde3D/Source/Horde3DEngine/egResource.h
+++ b/Horde3D/Source/Horde3DEngine/egResource.h
@@ -53,8 +53,9 @@ struct ResourceFlags
 		NoTexMipmaps = 4,
 		TexCubemap = 8,
 		TexDynamic = 16,
-		TexRenderable = 32,
-		TexSRGB = 64
+		TexSRGB = 32,
+		TexRenderable = 64,
+		TexDepthBuffer = 128,
 	};
 };
 

--- a/Horde3D/Source/Horde3DEngine/egSceneGraphRes.h
+++ b/Horde3D/Source/Horde3DEngine/egSceneGraphRes.h
@@ -44,8 +44,9 @@ public:
 	SceneNodeTpl *getRootNode() const { return _rootNode; }
 
 private:
+	bool raiseError( const std::string &msg );
 	void parseBaseAttributes( XMLNode &xmlNode, SceneNodeTpl &nodeTpl );
-	void parseNode( XMLNode &xmlNode, SceneNodeTpl *parentTpl );
+	bool parseNode( XMLNode &xmlNode, SceneNodeTpl *parentTpl );
 
 private:
 	SceneNodeTpl	*_rootNode;

--- a/Horde3D/Source/Horde3DEngine/egTexture.cpp
+++ b/Horde3D/Source/Horde3DEngine/egTexture.cpp
@@ -223,7 +223,7 @@ TextureResource::TextureResource( const string &name, uint32 width, uint32 heigh
 		_flags |= ResourceFlags::NoTexCompression;
 		_texType = TextureTypes::Tex2D;
 		_sRGB = false;
-		_rbObj = rdi->createRenderBuffer( width, height, fmt, false, 1, 0, _hasMipMaps ); 
+		_rbObj = rdi->createRenderBuffer( width, height, fmt, flags & ResourceFlags::TexDepthBuffer, 1, 0, _hasMipMaps );
 		_texObject = rdi->getRenderBufferTex( _rbObj, 0 );
 	}
 	else

--- a/Horde3D/Source/Horde3DEngine/egTexture.cpp
+++ b/Horde3D/Source/Horde3DEngine/egTexture.cpp
@@ -231,14 +231,20 @@ TextureResource::TextureResource( const string &name, uint32 width, uint32 heigh
 		uint32 size = rdi->calcTextureSize( _texFormat, width, height, depth );
 		unsigned char *pixels = new unsigned char[size];
 		memset( pixels, 0, size );
-		
+
 		_texType = flags & ResourceFlags::TexCubemap ? TextureTypes::TexCube : TextureTypes::Tex2D;
 		if( depth > 1 ) _texType = TextureTypes::Tex3D;
 		_sRGB = (_flags & ResourceFlags::TexSRGB) != 0;
 		_texObject = rdi->createTexture( _texType, _width, _height, _depth, _texFormat,
 		                                 _maxMipLevel, _maxMipLevel > 0, false, _sRGB );
-		rdi->uploadTextureData( _texObject, 0, 0, pixels );
-		
+
+		int nSlices = _texType != TextureTypes::TexCube ? 6 : 1;
+		for ( int mipLevel = 0; mipLevel <= _maxMipLevel; ++mipLevel ) {
+			for (int slice = 0; slice < nSlices; ++slice ) {
+				rdi->uploadTextureData( _texObject, slice, mipLevel, pixels );
+			}
+		}
+
 		delete[] pixels;
 		if( _texObject == 0 ) initDefault();
 	}

--- a/Horde3D/Source/Horde3DEngine/egTexture.h
+++ b/Horde3D/Source/Horde3DEngine/egTexture.h
@@ -72,7 +72,7 @@ public:
 	uint32 getDepth() const { return _depth; }
 	uint32 getTexObject() const { return _texObject; }
 	uint32 getRBObject() const { return _rbObj; }
-	bool hasMipMaps() const { return _hasMipMaps; }
+	uint32 getMaxMipLevel() const { return _maxMipLevel; }
 
 public:
 	static uint32	defTex2DObject;
@@ -87,8 +87,8 @@ protected:
 	bool loadKTX( const char *data, int size );
 	bool loadDDS( const char *data, int size );
 	bool loadSTBI( const char *data, int size );
-	int getMipCount() const;
-	
+    uint32 getMaxAtMipFullLevel() const;
+
 protected:
 	static unsigned char  *mappedData;
 	static int            mappedWriteImage;
@@ -97,9 +97,9 @@ protected:
 	TextureFormats::List  _texFormat;
 	int                   _width, _height, _depth;
 	uint32                _texObject;
-	uint32                _rbObj;  // Used when texture is renderable
+	uint32                _rbObj;           // Used when texture is renderable
+	uint32                _maxMipLevel;     // number of mip levels = _maxMipLevel + 1
 	bool                  _sRGB;
-	bool                  _hasMipMaps;
 
 	friend class ResourceManager;
 };

--- a/Horde3D/Source/Shared/rapidxml.h
+++ b/Horde3D/Source/Shared/rapidxml.h
@@ -31,11 +31,6 @@
 #ifndef RAPIDXML_HPP_INCLUDED
 #define RAPIDXML_HPP_INCLUDED
 
-// =================================================================================================
-#define RAPIDXML_NO_EXCEPTIONS
-
-// =================================================================================================
-
 // If standard library is disabled, user must provide implementations of required functions and typedefs
 #if !defined(RAPIDXML_NO_STDLIB)
     #include <cstdlib>      // For std::size_t

--- a/Horde3D/Source/Shared/utMath.h
+++ b/Horde3D/Source/Shared/utMath.h
@@ -63,17 +63,17 @@ namespace Math
 // General
 // -------------------------------------------------------------------------------------------------
 
-static inline float degToRad( float f ) 
+inline float degToRad( float f )
 {
 	return f * 0.017453293f;
 }
 
-static inline float radToDeg( float f ) 
+inline float radToDeg( float f )
 {
 	return f * 57.29577951f;
 }
 
-static inline float clamp( float f, float min, float max )
+inline float clamp( float f, float min, float max )
 {
 	if( f < min ) f = min;
 	else if( f > max ) f = max;
@@ -81,17 +81,17 @@ static inline float clamp( float f, float min, float max )
 	return f;
 }
 
-static inline float minf( float a, float b )
+inline float minf( float a, float b )
 {
 	return a < b ? a : b;
 }
 
-static inline float maxf( float a, float b )
+inline float maxf( float a, float b )
 {
 	return a > b ? a : b;
 }
 
-static inline float fsel( float test, float a, float b )
+inline float fsel( float test, float a, float b )
 {
 	// Branchless selection
 	return test >= 0 ? a : b;
@@ -99,7 +99,7 @@ static inline float fsel( float test, float a, float b )
 
 // Computes a/b, rounded up
 // To be used for positive a and b and small numbers (beware of overflows)
-static inline int idivceil( int a, int b )
+inline int idivceil( int a, int b )
 {
 	return (a + b - 1) / b;
 }
@@ -109,14 +109,14 @@ static inline int idivceil( int a, int b )
 // Conversion
 // -------------------------------------------------------------------------------------------------
 
-static inline int ftoi_t( double val )
+inline int ftoi_t( double val )
 {
 	// Float to int conversion using truncation
 	
 	return (int)val;
 }
 
-static inline int ftoi_r( double val )
+inline int ftoi_r( double val )
 {
 	// Fast round (banker's round) using Sree Kotay's method
 	// This function is much faster than a naive cast from float to int
@@ -155,10 +155,6 @@ public:
 	}
 	
 	Vec2f( const float x, const float y ) : x( x ), y( y )
-	{
-	}
-	
-	Vec2f( const Vec2f &v ) : x( v.x ), y( v.y )
 	{
 	}
 	
@@ -293,10 +289,6 @@ public:
 	}
 	
 	Vec3f( const float x, const float y, const float z ) : x( x ), y( y ), z( z ) 
-	{
-	}
-
-	Vec3f( const Vec3f &v ) : x( v.x ), y( v.y ), z( v.z )
 	{
 	}
 

--- a/Horde3D/Source/Shared/utXML.h
+++ b/Horde3D/Source/Shared/utXML.h
@@ -23,9 +23,14 @@
 #include "rapidxml.h"
 
 
+#ifdef RAPIDXML_NO_EXCEPTIONS
 inline void rapidxml::parse_error_handler( const char *what, void *where )
 {
+	// When not using exceptions, program has to be terminated on xml error
+	fprintf( stderr, "Parse error: %s\n", what );
+	std::abort();
 }
+#endif
 
 
 namespace Horde3D {
@@ -88,15 +93,20 @@ protected:
 class XMLDoc
 {
 public:
-	XMLDoc() : buf( 0x0 ) {}
+	XMLDoc() : buf( 0x0 ), err(false) {}
 	~XMLDoc() { delete[] buf; }
 	
-	bool hasError() const { return doc.first_node() == 0x0; }
+	bool hasError() const { return err || doc.first_node() == 0x0; }
 	XMLNode getRootNode() const { return XMLNode( doc.first_node() ); }
 	
 	void parseString( char *text )
 	{
+#ifdef RAPIDXML_NO_EXCEPTIONS
 		doc.parse< rapidxml::parse_validate_closing_tags >( text );
+#else
+		try { doc.parse< rapidxml::parse_validate_closing_tags >( text ); }
+		catch (const std::exception&) { err = true; }
+#endif
 	}
 
 	void parseBuffer( const char *charbuf, int size )
@@ -130,6 +140,7 @@ public:
 private:
 	rapidxml::xml_document<>  doc;
 	char                      *buf;
+	bool                      err;
 };
 
 


### PR DESCRIPTION
Thanks for the feedback. I closed the other pull request and opened a new one with a reviewed patch set.

It should address both issues:
- Makes enabling exceptions for handling xml errors optional (default off)
- Initialises the texture content to zero (including cube map and mipmap case)

Please let me know if there are further comments.