### PR TITLE
Don't call `uploadTextureData` with null pointer for pixel data

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -780,6 +780,7 @@ void RenderDeviceGL2::generateTextureMipmap( uint32 texObj )
 
 void RenderDeviceGL2::uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels )
 {
+	ASSERT( pixels );
 	const RDITextureGL2 &tex = _textures.getRef( texObj );
 	TextureFormats::List format = tex.format;
 
@@ -1226,7 +1227,6 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, maxMipLevel, maxMipLevel > 0, false, false );
 			ASSERT( texObj != 0 );
-			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
 			RDITextureGL2 &tex = _textures.getRef( texObj );
 			glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, rb.fbo );
@@ -1279,7 +1279,6 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 		uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, 0, false, false, false );
 		ASSERT( texObj != 0 );
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE );
-		uploadTextureData( texObj, 0, 0, 0x0 );
 		rb.depthTex = texObj;
 		RDITextureGL2 &tex = _textures.getRef( texObj );
 		// Attach the texture

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL4.cpp
@@ -905,6 +905,7 @@ void RenderDeviceGL4::generateTextureMipmap( uint32 texObj )
 
 void RenderDeviceGL4::uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels )
 {
+	ASSERT( pixels );
 	const RDITextureGL4 &tex = _textures.getRef( texObj );
 	TextureFormats::List format = tex.format;
 
@@ -1501,7 +1502,6 @@ uint32 RenderDeviceGL4::createRenderBuffer( uint32 width, uint32 height, Texture
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, maxMipLevel, maxMipLevel > 0, false, false );
 			ASSERT( texObj != 0 );
-			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
 			RDITextureGL4 &tex = _textures.getRef( texObj );
 			glBindFramebuffer( GL_FRAMEBUFFER, rb.fbo );
@@ -1554,7 +1554,6 @@ uint32 RenderDeviceGL4::createRenderBuffer( uint32 width, uint32 height, Texture
 		uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, 0, false, false, false );
 		ASSERT( texObj != 0 );
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE );
-		uploadTextureData( texObj, 0, 0, 0x0 );
 		rb.depthTex = texObj;
 		RDITextureGL4 &tex = _textures.getRef( texObj );
 		// Attach the texture

--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGLES3.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGLES3.cpp
@@ -847,6 +847,7 @@ void RenderDeviceGLES3::generateTextureMipmap( uint32 texObj )
 
 void RenderDeviceGLES3::uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels )
 {
+	ASSERT( pixels );
 	const RDITextureGLES3 &tex = _textures.getRef( texObj );
 	TextureFormats::List format = tex.format;
 
@@ -1603,7 +1604,6 @@ uint32 RenderDeviceGLES3::createRenderBuffer( uint32 width, uint32 height, Textu
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, maxMipLevel, maxMipLevel > 0, false, false );
 			ASSERT( texObj != 0 );
-			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[ j ] = texObj;
 			RDITextureGLES3 &tex = _textures.getRef( texObj );
 			// Attach the texture
@@ -1670,7 +1670,6 @@ uint32 RenderDeviceGLES3::createRenderBuffer( uint32 width, uint32 height, Textu
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, 0, false, false, false );
 			ASSERT( texObj != 0 );
 			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE );
-			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.depthTex = texObj;
 			RDITextureGLES3 &tex = _textures.getRef( texObj );
 			// Attach the texture


### PR DESCRIPTION
The recent commit about supporting partial mipmap levels changed the semantics
of `createTexture` and `uploadTextureData`. Previously `uploadTextureData` could
be used to allocated texture memory by providing a null pointer for pixel data.
Now `createTexture` always allocates texture memory and `uploadTextureData`
shouldn't be called with null pointer for pixel data anymore.
`glTexSubImage2D` segfaults on Nvidia driver if pixel data is null pointer.