### PR TITLE
Fix terrain engine/sample on Android and iOS

### DIFF
--- a/Horde3D/Source/Horde3DEngine/utOpenGLES3.h
+++ b/Horde3D/Source/Horde3DEngine/utOpenGLES3.h
@@ -89,10 +89,10 @@ bool initOpenGLExtensions();
 #import <OpenGLES/ES3/glext.h>
 #define GL_GLEXT_PROTOTYPES
 #elif defined(PLATFORM_ANDROID) || defined(PLATFORM_NACL) || defined(PLATFORM_QNX)
-#include <GLES3/gl32.h>
+#include <GLES3/gl31.h>
 // #define GL_GLEXT_PROTOTYPES
 // #include <GLES3/gl3platform.h>
-// #include <GLES2/gl2ext.h>
+//#include <GLES2/gl2ext.h>
 #endif
 
 // =================================================================================================


### PR DESCRIPTION
It was a really peculiar bug that originated from different color models used in desktop OpenGL and OpenGL ES (desktop GL uses BGRA and ES uses RGBA). As terrain extension assumes that texture is really BGRA and it is not so for OpenGL ES, we took wrong color channels for height and had incorrect rendering.

Directional lighting is slowly being worked on.