### PR TITLE
Fix GL4 on AMD and GL2 on all cards

### DIFF
--- a/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRendererBaseGL2.cpp
@@ -793,7 +793,6 @@ void RenderDeviceGL2::generateTextureMipmap( uint32 texObj )
 
 void RenderDeviceGL2::uploadTextureData( uint32 texObj, int slice, int mipLevel, const void *pixels )
 {
-	ASSERT( pixels );
 	const RDITextureGL2 &tex = _textures.getRef( texObj );
 	TextureFormats::List format = tex.format;
 
@@ -1240,6 +1239,7 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 			// Create a color texture
 			uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, format, maxMipLevel, maxMipLevel > 0, false, false );
 			ASSERT( texObj != 0 );
+			uploadTextureData( texObj, 0, 0, 0x0 );
 			rb.colTexs[j] = texObj;
 			RDITextureGL2 &tex = _textures.getRef( texObj );
 			glBindFramebufferEXT( GL_FRAMEBUFFER_EXT, rb.fbo );
@@ -1292,6 +1292,7 @@ uint32 RenderDeviceGL2::createRenderBuffer( uint32 width, uint32 height, Texture
 		uint32 texObj = createTexture( TextureTypes::Tex2D, rb.width, rb.height, 1, TextureFormats::DEPTH, 0, false, false, false );
 		ASSERT( texObj != 0 );
 		glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE );
+		uploadTextureData( texObj, 0, 0, 0x0 );
 		rb.depthTex = texObj;
 		RDITextureGL2 &tex = _textures.getRef( texObj );
 		// Attach the texture

--- a/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
+++ b/Horde3D/Source/Horde3DEngine/utOpenGL.cpp
@@ -761,10 +761,10 @@ void initModernExtensions( bool &r )
 	glExt::KHR_debug = isExtensionSupported( "GL_KHR_debug" );
 	if ( glExt::KHR_debug )
 	{
-		r &= ( glDebugMessageCallbackKHR = ( PFNGLDEBUGMESSAGECALLBACKKHRPROC ) platGetProcAddress( "glDebugMessageCallbackKHR" ) ) != 0x0;
-		r &= ( glDebugMessageControlKHR = ( PFNGLDEBUGMESSAGECONTROLKHRPROC ) platGetProcAddress( "glDebugMessageControlKHR" ) ) != 0x0;
-		r &= ( glDebugMessageInsertKHR = ( PFNGLDEBUGMESSAGEINSERTKHRPROC ) platGetProcAddress( "glDebugMessageInsertKHR" ) ) != 0x0;
-		r &= ( glGetDebugMessageLogKHR = ( PFNGLGETDEBUGMESSAGELOGKHRPROC ) platGetProcAddress( "glGetDebugMessageLogKHR" ) ) != 0x0;
+		r &= ( glDebugMessageCallbackKHR = ( PFNGLDEBUGMESSAGECALLBACKKHRPROC ) platGetProcAddress( "glDebugMessageCallback" ) ) != 0x0;
+		r &= ( glDebugMessageControlKHR = ( PFNGLDEBUGMESSAGECONTROLKHRPROC ) platGetProcAddress( "glDebugMessageControl" ) ) != 0x0;
+		r &= ( glDebugMessageInsertKHR = ( PFNGLDEBUGMESSAGEINSERTKHRPROC ) platGetProcAddress( "glDebugMessageInsert" ) ) != 0x0;
+		r &= ( glGetDebugMessageLogKHR = ( PFNGLGETDEBUGMESSAGELOGKHRPROC ) platGetProcAddress( "glGetDebugMessageLog" ) ) != 0x0;
 	}
 }
 


### PR DESCRIPTION
This pull request fixes the behavior that is described in #171 (problems with khr_debug extension on amd cards and failure to use gl2 render backend).