### PR TITLE
Fix fallback path from gl4 render backend to gl2 backend

### DIFF
--- a/Horde3D/Samples/Framework/sampleapp.h
+++ b/Horde3D/Samples/Framework/sampleapp.h
@@ -143,7 +143,9 @@ public:
 	
 protected:
 //     GLFWwindow* getWindowHandle() const { return _winHandle; }
-	virtual BackendInitParameters setupInitParameters();
+    int defaultRenderInterface();
+
+	virtual BackendInitParameters setupInitParameters( int render_interface );
 	virtual WindowCreateParameters setupWindowParameters();
 
     virtual bool initResources();

--- a/Horde3D/Source/Horde3DEngine/egRenderer.cpp
+++ b/Horde3D/Source/Horde3DEngine/egRenderer.cpp
@@ -211,21 +211,7 @@ bool Renderer::init( RenderBackendType::List type )
 	{
 		releaseRenderDevice();
 
-		if ( type == RenderBackendType::OpenGL4 )
-		{
-			// try to use legacy OpenGL renderer backend
-			_renderDevice = createRenderDevice( RenderBackendType::OpenGL2 );
-			if ( !_renderDevice ) return false;
-
-			if ( !_renderDevice->init() )
-			{
-				releaseRenderDevice();
-				return false;
-			}
-			type = RenderBackendType::OpenGL2;
-		}
-		else
-			return false;
+		return false;
 	}
 
 	// Check capabilities


### PR DESCRIPTION
This should fix #171 permanently. Moved fallback path from engine to sample framework. Checked on Linux + Mesa on glfw and sdl backends.