### PR TITLE
ColladaConv : `-useMaterialId` let use `id=` for `.material.xml`

### DIFF
--- a/Horde3D/Source/ColladaConverter/main.cpp
+++ b/Horde3D/Source/ColladaConverter/main.cpp
@@ -131,6 +131,7 @@ void printHelp()
 	log( "-lodDist2 dist    distance for LOD2" );
 	log( "-lodDist3 dist    distance for LOD3" );
 	log( "-lodDist4 dist    distance for LOD4" );
+	log( "-useMaterialId    use material id instead of material name" );
 }
 
 
@@ -152,7 +153,7 @@ int main( int argc, char **argv )
 	vector< string > assetList;
 	string input = argv[1], basePath = "./", outPath = "./";
 	AssetTypes::List assetType = AssetTypes::Model;
-	bool geoOpt = true, overwriteMats = false, addModelName = false;
+	bool geoOpt = true, overwriteMats = false, addModelName = false, useMaterialId=false;
 	float lodDists[4] = { 10, 20, 40, 80 };
 	string modelName = "";	
 
@@ -205,6 +206,10 @@ int main( int argc, char **argv )
 		else if( _stricmp( arg.c_str(), "-addModelName" ) == 0 )
 		{
 			addModelName = true;
+		}
+		else if( _stricmp( arg.c_str(), "-useMaterialId" ) == 0 )
+		{
+			useMaterialId = true;
 		}
 		else
 		{
@@ -272,6 +277,14 @@ int main( int argc, char **argv )
 			log( "Parsing dae asset '" + assetList[i] + "'..." );
 			if( !daeDoc->parseFile( sourcePath ) )
 				return 1;
+
+			if( useMaterialId )
+			{
+				for( unsigned int i = 0; i < daeDoc->libMaterials.materials.size(); ++i )
+				{
+					daeDoc->libMaterials.materials[i]->name = daeDoc->libMaterials.materials[i]->id;
+				}
+			}
 			
 			if( assetType == AssetTypes::Model )
 			{

--- a/Horde3D/Source/ColladaConverter/main.cpp
+++ b/Horde3D/Source/ColladaConverter/main.cpp
@@ -153,7 +153,7 @@ int main( int argc, char **argv )
 	vector< string > assetList;
 	string input = argv[1], basePath = "./", outPath = "./";
 	AssetTypes::List assetType = AssetTypes::Model;
-	bool geoOpt = true, overwriteMats = false, addModelName = false, useMaterialId=false;
+	bool geoOpt = true, overwriteMats = false, addModelName = false, useMaterialId = false;
 	float lodDists[4] = { 10, 20, 40, 80 };
 	string modelName = "";	
 
@@ -278,6 +278,11 @@ int main( int argc, char **argv )
 			if( !daeDoc->parseFile( sourcePath ) )
 				return 1;
 
+			// By default, material's names are used to make `.material.xml` filenames.
+			// These names might contains filesystem's reserved characters that might cause unexpected 
+			// issues when transfering files from one filesystem to an other.
+			// The command line arguement `-useMaterialId` allow to use material's `id` instead of names,
+			// as `id` are less prone to contain reserved characters.
 			if( useMaterialId )
 			{
 				for( unsigned int i = 0; i < daeDoc->libMaterials.materials.size(); ++i )


### PR DESCRIPTION
Regarding : https://github.com/horde3d/Horde3D/issues/193

Without this patch, `ColladaConv` will use the `name` attribute (if available) of each material to generate the `.material.xml` filenames.

The problem is that, sometimes, this `material.name` contains special reserved characters that will cause unexpected issues with some file-system, and renaming each material in the "DCC tool-chain" might be time consuming.

As the `id` attribute of each material follows the XML schema `xs:ID` rule,  it should be safer to use it to make `.material.xml` filenames.

This patch adds a new `-useMaterialId` command line argument that tells to `ColladaConv` to use `material.id` instead of `material.name`.


-----------
# Rationalisation :

Ok, so according to [Collada Spec 1.4 page 8.54](https://www.khronos.org/files/collada_spec_1_4.pdf) : the `id` attribute of `<material>` is of type `xs:ID`.

According to [xml-schema](https://www.oreilly.com/library/view/xml-schema/0596002521/re74.html) : `xs:ID` is derived from `xs:NCName`.

According to [xml-schema](https://www.oreilly.com/library/view/xml-schema/0596002521/re82.html) : the `xs:NCName` valid pattern is `[\i-[:]][\c-[:]]*`.

And according to [this page](https://www.regular-expressions.info/shorthand.html#xml): 
- if pure ASCII, `\i` could translates to `[_:A-Za-z]` and `\c` could translates to `[-._:A-Za-z0-9]`
- the `-[:]` excludes `:` from the `\i` and `\c` classes of characters.

So, `[\i-[:]][\c-[:]]*` translates into english to : 
- ONE valid unicode letter or `_`, followed by any number of unicode letters, digits, `_` or `-` or `.` 

So, if this is correct, using the `id` attribute of `<material>` to generate the `.material.xml` filenames is safer than using its name attribute.