### PR TITLE
Include math.h in utPlatform.h for `_atof_l`.

### DIFF
--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -13,6 +13,7 @@
 #ifndef _utPlatform_H_
 #define _utPlatform_H_
 
+#include <math.h>
 #include <locale.h>
 #include <memory>
 #if !defined( NDEBUG )

--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -13,11 +13,13 @@
 #ifndef _utPlatform_H_
 #define _utPlatform_H_
 
-#include <math.h>
 #include <locale.h>
 #include <memory>
 #if !defined( NDEBUG )
 	#include <assert.h>
+#endif
+#if defined(__MINGW32__)
+	#include <math.h>
 #endif
 
 // Detect platform


### PR DESCRIPTION
MinGW (MSYS2) throws `error: '_atof_l' was not declared in this scope; did you mean '_wtof_l'?`