### PR TITLE
getGLTexID() now works for GLES3 as well

### DIFF
--- a/Extensions/ExternalTexture/Source/egTextureEx.cpp
+++ b/Extensions/ExternalTexture/Source/egTextureEx.cpp
@@ -18,6 +18,7 @@
 
 #include "egRendererBaseGL2.h"
 #include "egRendererBaseGL4.h"
+#include "egRendererBaseGLES3.h"
 
 namespace  Horde3DExternalTexture {
 
@@ -69,6 +70,12 @@ uint32 TextureResourceEx::getGLTexID()
 		RDI_GL4::RDITextureGL4& tex = rdi->getTexture( _texObject );
 		return tex.glObj;
 	}
+    case RenderBackendType::OpenGLES3:
+    {
+        RDI_GLES3::RenderDeviceGLES3 *rdi = ( RDI_GLES3::RenderDeviceGLES3 * ) Modules::renderer().getRenderDevice();
+        RDI_GLES3::RDITextureGLES3& tex = rdi->getTexture( _texObject );
+        return tex.glObj;
+    }
 	default:
 		Modules::log().writeError("Render backend not supported");
 		return 0;


### PR DESCRIPTION
The 'getGLTexID()' of the 'Horde3DExternalTexture' extension now works for GLES3 as well.
It was mostly just copy-paste and renaming some stuff, and it worked