### PR TITLE
Update utPlatform.h

### DIFF
--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -20,6 +20,7 @@
 #endif
 #if defined(__MINGW32__)
 	#include <math.h>
+	#include <cstdint>
 #endif
 
 // Detect platform


### PR DESCRIPTION
tested with gcc 15 from: https://github.com/skeeto/w64devkit/releases/tag/v2.3.0

I don't know why cstdint is required but works with gcc 15 and older.




`
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp: In member function 'bool Horde3D::ShaderParser::parseBi
naryContextShaderCombs(char*&, uint32)':
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp:584:13: error: 'uint8_t' was not declared in this scope
  584 |             uint8_t *combinationShaderData = new uint8_t[ combinationShaderSize ];
      |             ^~~~~~~
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp:7:1: note: 'uint8_t' is defined in header '<cstdint>'; t
his is probably fixable by adding '#include <cstdint>'
    6 | #include "egRenderer.h"
  +++ |+#include <cstdint>
    7 |
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp:584:22: error: 'combinationShaderData' was not declared
in this scope; did you mean 'combinationShaderSize'?
  584 |             uint8_t *combinationShaderData = new uint8_t[ combinationShaderSize ];
      |                      ^~~~~~~~~~~~~~~~~~~~~
      |                      combinationShaderSize
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp:584:50: error: 'uint8_t' does not name a type
  584 |             uint8_t *combinationShaderData = new uint8_t[ combinationShaderSize ];
      |                                                  ^~~~~~~
C:\3ds4\Horde3D\Horde3D\Source\Horde3DEngine\egShaderParser.cpp:584:50: note: 'uint8_t' is defined in header '<cstdint>'
; this is probably fixable by adding '#include <cstdint>'
make[2]: *** [Horde3D\Source\Horde3DEngine\CMakeFiles\Horde3D.dir\build.make:391: Horde3D/Source/Horde3DEngine/CMakeFile
s/Horde3D.dir/egShaderParser.cpp.obj] Error 1
make[1]: *** [CMakeFiles\Makefile2:588: Horde3D/Source/Horde3DEngine/CMakeFiles/Horde3D.dir/all] Error 2
make: *** [Makefile:90: all] Error 2
Press any key to continue . . .

`