### PR TITLE
Fixed build when using GCC-15, in native linux environment.

### DIFF
--- a/Horde3D/Source/Shared/utPlatform.h
+++ b/Horde3D/Source/Shared/utPlatform.h
@@ -18,7 +18,7 @@
 #if !defined( NDEBUG )
 	#include <assert.h>
 #endif
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) || (__GNUC__ >= 14)
 	#include <math.h>
 	#include <cstdint>
 #endif


### PR DESCRIPTION
same issue as 
[3c31068](https://github.com/horde3d/Horde3D/commit/3c3106896f87c416df947b0c0ea9f0a069fac46b)

That commit would fix it if you were using mingw. But building it straight from gcc would still fail, so I added a condition for GCC >= 14 as well ( 14 just to be safe )

Some extra detail:
 - This error does not happen on gcc-14.2.1
 - Error happens on gcc-15.1

So somewhere in between the error appears. 