### PR TITLE
Small oversight where the CI would not build the release version of the iOS examples

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -121,4 +121,4 @@ jobs:
       - name: Build
         run: |
           cd build
-          xcodebuild -project Horde3D.xcodeproj -configuration Debug -sdk iphoneos build
+          xcodebuild -project Horde3D.xcodeproj -configuration ${{matrix.build_type}} -sdk iphoneos build


### PR DESCRIPTION
sorry I didn't discover it at the first pull request #249 