### PR TITLE
Fixed issue where multiple spaces between values in the .dae file would result in faulty materials

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,6 +36,13 @@ jobs:
           cd build
           make -j $threads
 
+      - name: Print build errors
+        if: ${{ failure() }}
+        run: |
+          echo "==== logs in $(pwd) ===="
+          find ./ -name "*.log" -print -exec cat {} \;
+          exit 1
+
       - name: Run tests
         id: run_tests
         run: |

--- a/BuildTools/CMake/Modules/FindGLFW.cmake
+++ b/BuildTools/CMake/Modules/FindGLFW.cmake
@@ -49,9 +49,9 @@ IF(NOT GLFW_LIBRARY_PATH OR HORDE3D_FORCE_DOWNLOAD_GLFW)
     # It uses CMake's "ExternalProject_Add" target.
     MESSAGE(STATUS "Preparing external GLFW project")
     INCLUDE(ExternalProject)
-    ExternalProject_Add(project_glfw 
-        URL https://github.com/glfw/glfw/releases/download/3.3.2/glfw-3.3.2.zip
-        URL_MD5 f794d9ad899a64894782884be79d644b
+    ExternalProject_Add(project_glfw
+        URL https://github.com/glfw/glfw/releases/download/3.3.10/glfw-3.3.10.zip
+        URL_MD5 ca85f61c76a041e8be1a9f6e76e189f6
         CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_INSTALL_LIBDIR:PATH=lib -DGLFW_BUILD_DOCS:BOOL=OFF -DGLFW_BUILD_EXAMPLES:BOOL=OFF -DGLFW_BUILD_TESTS:BOOL=OFF
         LOG_DOWNLOAD 1
         LOG_UPDATE 1

--- a/Horde3D/Source/ColladaConverter/converter.cpp
+++ b/Horde3D/Source/ColladaConverter/converter.cpp
@@ -1324,7 +1324,7 @@ bool Converter::writeMaterials( const string &assetPath, const string &modelName
 				char value = 'a';
 				std::istringstream iss(material.effect->diffuseColor);
 				std::string token;
-				while(std::getline(iss, token, ' '))
+				while(getWord(iss, token))
 				{
 					outf << value++ << "=\"" << token << "\" ";
 				}				
@@ -1337,7 +1337,7 @@ bool Converter::writeMaterials( const string &assetPath, const string &modelName
 				char value = 'a';
 				std::istringstream iss(material.effect->specularColor);
 				std::string token;
-				while(std::getline(iss, token, ' ') && value < 'd' )
+				while(getWord(iss, token) && value < 'd' )
 				{
 					outf << value++ << "=\"" << token << "\" ";
 				}				

--- a/Horde3D/Source/ColladaConverter/utils.cpp
+++ b/Horde3D/Source/ColladaConverter/utils.cpp
@@ -116,6 +116,37 @@ string cleanPath( const string &path )
 		return cleanedPath;
 }
 
+bool getWord(istringstream& in, string& out, const std::string& delimiterChars)
+{
+	out.clear();
+	char c;
+
+	// skip leading delimiters
+	while (in.get(c))
+	{
+		if (delimiterChars.find(c) == string::npos)
+		{
+			out.push_back(c);
+			break;
+		}
+	}
+	if (out.empty())
+	{
+		return false;
+	}
+
+	// Read until next delimiter
+	while (in.get(c))
+	{
+		if (delimiterChars.find(c) != string::npos)
+		{
+			break;
+		}
+		out.push_back(c);
+	}
+
+	return true;
+}
 
 void log( const std::string &msg, bool verboseMessage )
 {

--- a/Horde3D/Source/ColladaConverter/utils.h
+++ b/Horde3D/Source/ColladaConverter/utils.h
@@ -18,6 +18,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <string>
+#include <sstream>
 
 namespace Horde3D {
 namespace ColladaConverter {
@@ -28,6 +29,7 @@ std::string decodeURL( const std::string &url );
 std::string extractFileName( const std::string &fullPath, bool extension );
 std::string extractFilePath( const std::string &fullPath );
 std::string cleanPath( const std::string &path );
+bool getWord(std::istringstream& in, std::string& out, const std::string& delimiterChars = " \t");
 
 void log( const std::string &msg, bool verboseMessage = false );
 void logSetVerbose( bool verbose );


### PR DESCRIPTION
When exporting a .dae from AssImp, the materials will be formatted like so:
```
<diffuse>
  <color sid="diffuse">1   1   1   1</color>
</diffuse>
```

instead of (note the extra spaces):
```
<diffuse>
  <color sid="diffuse">1 1 1 1</color>
</diffuse>
```


The .dae from AssImp, with extra spaces between values produced the following material file:
```
<Material>
<Shader source="shaders/model.shader" />

<Uniform name="matDiffuseCol" a="1" b="" c="" d="1" e="" f="" g="1" h="" i="" j="1" />
</Material>
```

But we should only have a,b,c,d.
In this case, each additional spaces was considered a value. 

This pull request will fix that issue