### PR TITLE
Issue/docker reaches pull limit in ci

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,106 +7,122 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    # for all OS images, check https://github.com/actions/runner-images
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { compiler: gcc,   version: 4.9,  cppstd: 11, use_container: false } # old container not compatible with 'actions/checkout@v4'
-          - { compiler: gcc,   version: 11,   cppstd: 11, use_container: true  }
-          - { compiler: gcc,   version: 13,   cppstd: 20, use_container: true  }
-          - { compiler: gcc,   version: 15,   cppstd: 11, use_container: true, asan: ON }
-          - { compiler: clang, version: 3.6,  cppstd: 11, use_container: false } # old container not compatible with 'actions/checkout@v4'
-          - { compiler: clang, version: 11,   cppstd: 11, use_container: true  }
-          - { compiler: clang, version: 15,   cppstd: 17, use_container: true  }
-          - { compiler: clang, version: 20,   cppstd: 20, use_container: true, tsan: ON }
+          - { os: ubuntu-22.04, compiler: gcc,    version: 4.9,  cppstd: 11, } # old container not compatible with 'actions/checkout@v4'
+          - { os: ubuntu-22.04, compiler: gcc,    version: 11,   cppstd: 11, }
+          - { os: ubuntu-24.04, compiler: gcc,    version: 13,   cppstd: 20, }
+          - { os: ubuntu-24.04, compiler: gcc,    version: 15,   cppstd: 11, asan: ON }
+          - { os: ubuntu-22.04, compiler: clang,  version: 3.6,  cppstd: 11, } # old container not compatible with 'actions/checkout@v4'
+          - { os: ubuntu-22.04, compiler: clang,  version: 11,   cppstd: 11, }
+          - { os: ubuntu-24.04, compiler: clang,  version: 15,   cppstd: 17, }
+          - { os: ubuntu-24.04, compiler: clang,  version: 20,   cppstd: 20, tsan: ON }
         build_type: [ Debug, Release ]
 
-    container:
-      image: ${{ matrix.config.use_container && (matrix.config.compiler == 'clang' && format('teeks99/clang-ubuntu:{0}', matrix.config.version) || format('{0}:{1}', matrix.config.compiler, matrix.config.version)) || '' }}
+    runs-on:  ${{ matrix.config.os }}
 
     name: "${{ matrix.config.compiler}} ${{ matrix.config.version }} (C++${{ matrix.config.cppstd }} ${{ matrix.build_type }} ${{ matrix.config.asan == 'ON' && 'ASAN' || '' }}${{ matrix.config.tsan == 'ON' && 'TSAN' || '' }})"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup environment
-        run: echo "SUDO=$(if [ ${{ matrix.config.use_container }} = true ]; then echo ''; else echo 'sudo'; fi)" >> $GITHUB_ENV
-
       - name: Install dependencies
         run: |
           $SUDO apt update
           echo "installing dev libs"
-          $SUDO apt install -y cmake
+          sudo apt install -y cmake software-properties-common
+          echo "Adding test repo for more compiler version support"
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
           echo "installing openGL Libs"
           $SUDO apt install -y libglfw3-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev libgegl-dev libxext-dev
           echo "installing X11 libs"
           $SUDO apt install -y libxcursor-dev libx11-dev libxrandr-dev libxi-dev libxinerama-dev libxfixes-dev libxrender-dev libxxf86vm-dev
 
       # taken from 'https://github.com/fmtlib/fmt/actions/runs/16595627500/workflow'
-      - name: Install GCC 4.9
-        if: ${{ matrix.config.compiler == 'gcc' && matrix.config.version == '4.9' }}
+      - name: Install GCC ${{matrix.config.version}}
+        if: ${{ matrix.config.compiler == 'gcc' }}
         run: |
-          sudo apt install -y libatomic1 libc6-dev libgomp1 libitm1 libmpc3
-          # https://launchpad.net/ubuntu/xenial/amd64/g++-4.9/4.9.3-13ubuntu2
-          wget --no-verbose \
-            http://launchpadlibrarian.net/230069137/libmpfr4_3.1.3-2_amd64.deb \
-            http://launchpadlibrarian.net/253728424/libasan1_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/445346135/libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346112/libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/253728426/libgcc-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/253728432/libstdc++-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/253728314/gcc-4.9-base_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/445345919/gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/253728399/cpp-4.9_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/253728404/gcc-4.9_4.9.3-13ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/253728401/g++-4.9_4.9.3-13ubuntu2_amd64.deb
-          sudo dpkg -i \
-            libmpfr4_3.1.3-2_amd64.deb \
-            libasan1_4.9.3-13ubuntu2_amd64.deb \
-            libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libgcc-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
-            libstdc++-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
-            gcc-4.9-base_4.9.3-13ubuntu2_amd64.deb \
-            gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            cpp-4.9_4.9.3-13ubuntu2_amd64.deb \
-            gcc-4.9_4.9.3-13ubuntu2_amd64.deb \
-            g++-4.9_4.9.3-13ubuntu2_amd64.deb
+          if [ "${{matrix.config.version}}" = "4.9" ]; then
+            sudo apt install -y libatomic1 libc6-dev libgomp1 libitm1 libmpc3
+            # https://launchpad.net/ubuntu/xenial/amd64/g++-4.9/4.9.3-13ubuntu2
+            wget --no-verbose \
+              http://launchpadlibrarian.net/230069137/libmpfr4_3.1.3-2_amd64.deb \
+              http://launchpadlibrarian.net/253728424/libasan1_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/445346135/libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346112/libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/253728426/libgcc-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/253728432/libstdc++-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/253728314/gcc-4.9-base_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/445345919/gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/253728399/cpp-4.9_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/253728404/gcc-4.9_4.9.3-13ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/253728401/g++-4.9_4.9.3-13ubuntu2_amd64.deb
+            sudo dpkg -i \
+              libmpfr4_3.1.3-2_amd64.deb \
+              libasan1_4.9.3-13ubuntu2_amd64.deb \
+              libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libgcc-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
+              libstdc++-4.9-dev_4.9.3-13ubuntu2_amd64.deb \
+              gcc-4.9-base_4.9.3-13ubuntu2_amd64.deb \
+              gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              cpp-4.9_4.9.3-13ubuntu2_amd64.deb \
+              gcc-4.9_4.9.3-13ubuntu2_amd64.deb \
+              g++-4.9_4.9.3-13ubuntu2_amd64.deb
+          else
+            # Just use apt-get install if Listed here? https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu/1163021#1163021
+            sudo apt install -y gcc-${{matrix.config.version}} g++-${{matrix.config.version}}
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.config.version}} 200
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.config.version}} 200
+          fi
+          gcc --version
+          g++ --version
 
-      - name: Install Clang 3.6
-        if: ${{ matrix.config.compiler == 'clang' && matrix.config.version == '3.6' }}
+      - name: Install Clang ${{matrix.config.version}}
+        if: ${{ matrix.config.compiler == 'clang' }}
         run: |
-          sudo apt update
-          sudo apt install libtinfo5
-          # https://code.launchpad.net/ubuntu/xenial/amd64/clang-3.6/1:3.6.2-3ubuntu2
-          wget --no-verbose \
-            http://launchpadlibrarian.net/230019046/libffi6_3.2.1-4_amd64.deb \
-            http://launchpadlibrarian.net/445346109/libasan2_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346135/libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346112/libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346128/libmpx0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346113/libgcc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346131/libstdc++-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/445346022/libobjc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/254405108/libllvm3.6v5_3.6.2-3ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/254405097/libclang-common-3.6-dev_3.6.2-3ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/254405101/libclang1-3.6_3.6.2-3ubuntu2_amd64.deb \
-            http://launchpadlibrarian.net/445345919/gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            http://launchpadlibrarian.net/254405091/clang-3.6_3.6.2-3ubuntu2_amd64.deb
-          sudo dpkg -i \
-            libffi6_3.2.1-4_amd64.deb \
-            libasan2_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libmpx0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libgcc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libstdc++-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libobjc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            libllvm3.6v5_3.6.2-3ubuntu2_amd64.deb \
-            libclang-common-3.6-dev_3.6.2-3ubuntu2_amd64.deb \
-            libclang1-3.6_3.6.2-3ubuntu2_amd64.deb \
-            gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
-            clang-3.6_3.6.2-3ubuntu2_amd64.deb
+          if [ "${{matrix.config.version}}" = "3.6" ]; then
+            sudo apt install libtinfo5
+            # https://code.launchpad.net/ubuntu/xenial/amd64/clang-3.6/1:3.6.2-3ubuntu2
+            wget --no-verbose \
+              http://launchpadlibrarian.net/230019046/libffi6_3.2.1-4_amd64.deb \
+              http://launchpadlibrarian.net/445346109/libasan2_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346135/libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346112/libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346128/libmpx0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346113/libgcc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346131/libstdc++-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/445346022/libobjc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/254405108/libllvm3.6v5_3.6.2-3ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/254405097/libclang-common-3.6-dev_3.6.2-3ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/254405101/libclang1-3.6_3.6.2-3ubuntu2_amd64.deb \
+              http://launchpadlibrarian.net/445345919/gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              http://launchpadlibrarian.net/254405091/clang-3.6_3.6.2-3ubuntu2_amd64.deb
+            sudo dpkg -i \
+              libffi6_3.2.1-4_amd64.deb \
+              libasan2_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libubsan0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libcilkrts5_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libmpx0_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libgcc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libstdc++-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libobjc-5-dev_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              libllvm3.6v5_3.6.2-3ubuntu2_amd64.deb \
+              libclang-common-3.6-dev_3.6.2-3ubuntu2_amd64.deb \
+              libclang1-3.6_3.6.2-3ubuntu2_amd64.deb \
+              gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
+              clang-3.6_3.6.2-3ubuntu2_amd64.deb
+          else
+            sudo apt install -y clang-${{matrix.config.version}}
+            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{matrix.config.version}} 200
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{matrix.config.version}} 200
+            sudo update-alternatives --display clang  
+          fi
+          clang --version
+          clang++ --version
 
       - name: Setup Compiler
         if: ${{ matrix.config.compiler == 'clang' && matrix.config.use_container }}
@@ -213,7 +229,7 @@ jobs:
           echo "Building sample apk's failed. Printing logs..."
           cat ./build-android/project_sdl-prefix/src/project_sdl-stamp/project_sdl-build-*.log
           exit 1
-          
+
   emscripten:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,23 +30,23 @@ jobs:
 
       - name: Install dependencies
         run: |
-          $SUDO apt update
+          sudo apt-get update
           echo "installing dev libs"
-          sudo apt install -y cmake software-properties-common
+          sudo apt-get install -y cmake software-properties-common
           echo "Adding test repo for more compiler version support"
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
+          sudo apt-get update
           echo "installing openGL Libs"
-          $SUDO apt install -y libglfw3-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev libgegl-dev libxext-dev
+          sudo apt-get install -y libglfw3-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev libgegl-dev libxext-dev
           echo "installing X11 libs"
-          $SUDO apt install -y libxcursor-dev libx11-dev libxrandr-dev libxi-dev libxinerama-dev libxfixes-dev libxrender-dev libxxf86vm-dev
+          sudo apt-get install -y libxcursor-dev libx11-dev libxrandr-dev libxi-dev libxinerama-dev libxfixes-dev libxrender-dev libxxf86vm-dev
 
       # taken from 'https://github.com/fmtlib/fmt/actions/runs/16595627500/workflow'
       - name: Install GCC ${{matrix.config.version}}
         if: ${{ matrix.config.compiler == 'gcc' }}
         run: |
           if [ "${{matrix.config.version}}" = "4.9" ]; then
-            sudo apt install -y libatomic1 libc6-dev libgomp1 libitm1 libmpc3
+            sudo apt-get install -y libatomic1 libc6-dev libgomp1 libitm1 libmpc3
             # https://launchpad.net/ubuntu/xenial/amd64/g++-4.9/4.9.3-13ubuntu2
             wget --no-verbose \
               http://launchpadlibrarian.net/230069137/libmpfr4_3.1.3-2_amd64.deb \
@@ -74,7 +74,7 @@ jobs:
               g++-4.9_4.9.3-13ubuntu2_amd64.deb
           else
             # Just use apt-get install if Listed here? https://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu/1163021#1163021
-            sudo apt install -y gcc-${{matrix.config.version}} g++-${{matrix.config.version}}
+            sudo apt-get install -y gcc-${{matrix.config.version}} g++-${{matrix.config.version}}
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.config.version}} 200
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.config.version}} 200
           fi
@@ -85,7 +85,7 @@ jobs:
         if: ${{ matrix.config.compiler == 'clang' }}
         run: |
           if [ "${{matrix.config.version}}" = "3.6" ]; then
-            sudo apt install libtinfo5
+            sudo apt-get install libtinfo5
             # https://code.launchpad.net/ubuntu/xenial/amd64/clang-3.6/1:3.6.2-3ubuntu2
             wget --no-verbose \
               http://launchpadlibrarian.net/230019046/libffi6_3.2.1-4_amd64.deb \
@@ -116,7 +116,7 @@ jobs:
               gcc-5-base_5.4.0-6ubuntu1~16.04.12_amd64.deb \
               clang-3.6_3.6.2-3ubuntu2_amd64.deb
           else
-            sudo apt install -y clang-${{matrix.config.version}}
+            sudo apt-get install -y clang-${{matrix.config.version}}
             sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{matrix.config.version}} 200
             sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{matrix.config.version}} 200
             sudo update-alternatives --display clang  

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,7 +119,6 @@ jobs:
             sudo apt-get install -y clang-${{matrix.config.version}}
             sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{matrix.config.version}} 200
             sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{matrix.config.version}} 200
-            sudo update-alternatives --display clang  
           fi
           clang --version
           clang++ --version


### PR DESCRIPTION
Everytime when you push changes, docker pull will be called a couple for times ( for each gcc and clang version it wants to test ). This causes the docker pull hourly limit to be reached easily. 
Upon reaching the limit, the CI task will fail with the following error:
```
Starting job container
  /usr/bin/docker pull teeks99/clang-ubuntu:11
  Error response from daemon: Head "https://registry-1.docker.io/v2/teeks99/clang-ubuntu/manifests/11": toomanyrequests: too many failed login attempts for username or IP address
```

So to get around that, the use of docker within the CI has been removed.

**Note:**
The build for MacOS will fail, as the its CI now uses a newer cmake version. The fix for that is actually included in pull request [https://github.com/horde3d/Horde3D/pull/251](https://github.com/horde3d/Horde3D/pull/251)

I'm unsure if I should sherry pick that change, or leave it be in the other pull request. Let me know if you would like me to cherry pick that.